### PR TITLE
Remove Group-By for specific column

### DIFF
--- a/src/actions.spec.ts
+++ b/src/actions.spec.ts
@@ -55,14 +55,14 @@ const parser = sqlParserFactory(FUNCTIONS);
 
 describe('Ast action for segments test', () => {
   it('renders remove Column', () => {
-    const tree = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
+    const modifiedQuery = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
 FROM sys.segments
 ORDER BY "start" DESC
 LIMIT 25`)
       .excludeColumn('start')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT \\"segment_id\\", \\"datasource\\", \\"end\\", \\"size\\", \\"version\\", \\"partition_num\\", \\"num_replicas\\", \\"num_rows\\", \\"is_published\\", \\"is_available\\", \\"is_realtime\\", \\"is_overshadowed\\", \\"payload\\"
       FROM sys.segments
       LIMIT 25"
@@ -70,14 +70,14 @@ LIMIT 25`)
   });
 
   it('renders orderBy', () => {
-    const tree = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
+    const modifiedQuery = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
 FROM sys.segments
 ORDER BY "start" DESC
 LIMIT 25`)
       .orderBy('datasource', 'DESC')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT \\"segment_id\\", \\"datasource\\", \\"start\\", \\"end\\", \\"size\\", \\"version\\", \\"partition_num\\", \\"num_replicas\\", \\"num_rows\\", \\"is_published\\", \\"is_available\\", \\"is_realtime\\", \\"is_overshadowed\\", \\"payload\\"
       FROM sys.segments
       ORDER BY \\"datasource\\" DESC
@@ -86,14 +86,14 @@ LIMIT 25`)
   });
 
   it('renders exclude row', () => {
-    const tree = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
+    const modifiedQuery = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
 FROM sys.segments
 ORDER BY "start" DESC
 LIMIT 25`)
       .filterRow('datasource', 'github', '!=')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT \\"segment_id\\", \\"datasource\\", \\"start\\", \\"end\\", \\"size\\", \\"version\\", \\"partition_num\\", \\"num_replicas\\", \\"num_rows\\", \\"is_published\\", \\"is_available\\", \\"is_realtime\\", \\"is_overshadowed\\", \\"payload\\"
       FROM sys.segments
       WHERE \\"datasource\\" != 'github'
@@ -103,12 +103,12 @@ LIMIT 25`)
   });
 
   it('renders getSorted', () => {
-    const tree = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
+    const modifiedQuery = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
 FROM sys.segments
 ORDER BY "start" DESC
 LIMIT 25`).getSorted();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       Array [
         Object {
           "desc": true,
@@ -119,35 +119,35 @@ LIMIT 25`).getSorted();
   });
 
   it('renders getSchema', () => {
-    const tree = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
+    const modifiedQuery = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
 FROM sys.segments
 ORDER BY "start" DESC
 LIMIT 25`).getSchema();
-    expect(tree).toMatchInlineSnapshot(`"sys"`);
+    expect(modifiedQuery).toMatchInlineSnapshot(`"sys"`);
   });
 
   it('renders getTableName', () => {
-    const tree = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
+    const modifiedQuery = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
 FROM sys.segments
 ORDER BY "start" DESC
 LIMIT 25`).getTableName();
-    expect(tree).toMatchInlineSnapshot(`"segments"`);
+    expect(modifiedQuery).toMatchInlineSnapshot(`"segments"`);
   });
 
   it('renders getAggregateColumns', () => {
-    const tree = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
+    const modifiedQuery = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
 FROM sys.segments
 ORDER BY "start" DESC
 LIMIT 25`).getAggregateColumns();
-    expect(tree).toMatchInlineSnapshot(`undefined`);
+    expect(modifiedQuery).toMatchInlineSnapshot(`undefined`);
   });
 
   it('renders getColumnsArray', () => {
-    const tree = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
+    const modifiedQuery = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
 FROM sys.segments
 ORDER BY "start" DESC
 LIMIT 25`).getColumnsArray();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       Array [
         "segment_id",
         "datasource",
@@ -168,12 +168,12 @@ LIMIT 25`).getColumnsArray();
   });
 
   it('renders toString', () => {
-    const tree = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
+    const modifiedQuery = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
 FROM sys.segments
 ORDER BY "start" DESC
 LIMIT 25`).toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT \\"segment_id\\", \\"datasource\\", \\"start\\", \\"end\\", \\"size\\", \\"version\\", \\"partition_num\\", \\"num_replicas\\", \\"num_rows\\", \\"is_published\\", \\"is_available\\", \\"is_realtime\\", \\"is_overshadowed\\", \\"payload\\"
       FROM sys.segments
       ORDER BY \\"start\\" DESC
@@ -184,7 +184,7 @@ LIMIT 25`).toString();
 
 describe('Ast for full query action tests', () => {
   it('renders remove Column', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -199,7 +199,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
       .excludeColumn('datasource')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         COUNT(*) AS num_segments,
         SUM(is_available) AS num_available_segments,
@@ -215,7 +215,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
   });
 
   it('renders orderBy', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -230,7 +230,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
       .orderBy('datasource', 'DESC')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         datasource,
         COUNT(*) AS num_segments,
@@ -247,7 +247,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
   });
 
   it('renders exclude row', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -262,7 +262,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
       .filterRow('datasource', 'rowvalue', '!=')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         datasource,
         COUNT(*) AS num_segments,
@@ -280,7 +280,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
   });
 
   it('renders getSorted', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -292,7 +292,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
 FROM sys.segments
 GROUP BY 1,2
 ORDER BY "rank" DESC, "created_time" DESC`).getSorted();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       Array [
         Object {
           "desc": true,
@@ -307,7 +307,7 @@ ORDER BY "rank" DESC, "created_time" DESC`).getSorted();
   });
 
   it('renders getSchema', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -319,11 +319,11 @@ ORDER BY "rank" DESC, "created_time" DESC`).getSorted();
 FROM sys.segments
 GROUP BY 1,2
 ORDER BY "rank" DESC, "created_time" DESC`).getSchema();
-    expect(tree).toMatchInlineSnapshot(`"sys"`);
+    expect(modifiedQuery).toMatchInlineSnapshot(`"sys"`);
   });
 
   it('renders getTableName', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -335,11 +335,11 @@ ORDER BY "rank" DESC, "created_time" DESC`).getSchema();
 FROM sys.segments
 GROUP BY 1,2
 ORDER BY "rank" DESC, "created_time" DESC`).getTableName();
-    expect(tree).toMatchInlineSnapshot(`"segments"`);
+    expect(modifiedQuery).toMatchInlineSnapshot(`"segments"`);
   });
 
   it('renders getAggregateColumns', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -351,7 +351,7 @@ ORDER BY "rank" DESC, "created_time" DESC`).getTableName();
 FROM sys.segments
 GROUP BY 1,2
 ORDER BY "rank" DESC, "created_time" DESC`).getAggregateColumns();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       Array [
         "num_available_segments",
         "size",
@@ -362,7 +362,7 @@ ORDER BY "rank" DESC, "created_time" DESC`).getAggregateColumns();
   });
 
   it('renders getColumnsArray', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -374,7 +374,7 @@ ORDER BY "rank" DESC, "created_time" DESC`).getAggregateColumns();
 FROM sys.segments
 GROUP BY 1,2
 ORDER BY "rank" DESC, "created_time" DESC`).getColumnsArray();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       Array [
         "datasource",
         "num_segments",
@@ -387,7 +387,7 @@ ORDER BY "rank" DESC, "created_time" DESC`).getColumnsArray();
   });
 
   it('renders toString', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -400,7 +400,7 @@ FROM sys.segments
 GROUP BY 1,2
 ORDER BY "rank" DESC, "created_time" DESC`).toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         datasource,
         COUNT(*) AS num_segments,
@@ -419,7 +419,7 @@ ORDER BY "rank" DESC, "created_time" DESC`).toString();
 
 describe('Ast for full query including whereClause action tests', () => {
   it('renders remove Column', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -435,7 +435,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
       .excludeColumn('datasource')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         COUNT(*) AS num_segments,
         SUM(is_available) AS num_available_segments,
@@ -452,7 +452,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
   });
 
   it('renders remove Column', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -468,7 +468,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
       .excludeColumn('num_segments')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         datasource,
         SUM(is_available) AS num_available_segments,
@@ -485,7 +485,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
   });
 
   it('renders orderBy', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -501,7 +501,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
       .orderBy('datasource', 'DESC')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         datasource,
         COUNT(*) AS num_segments,
@@ -519,7 +519,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
   });
 
   it('renders exclude row', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -535,7 +535,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
       .filterRow('datasource', 'rowvalue', '!=')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         datasource,
         COUNT(*) AS num_segments,
@@ -553,7 +553,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
   });
 
   it('renders getSorted', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -566,7 +566,7 @@ FROM sys.segments
 WHERE "size" = '12'
 GROUP BY 1,2
 ORDER BY "rank" DESC, "created_time" DESC`).getSorted();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       Array [
         Object {
           "desc": true,
@@ -581,7 +581,7 @@ ORDER BY "rank" DESC, "created_time" DESC`).getSorted();
   });
 
   it('renders getSchema', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -594,11 +594,11 @@ FROM sys.segments
 WHERE "size" = '12'
 GROUP BY 1,2
 ORDER BY "rank" DESC, "created_time" DESC`).getSchema();
-    expect(tree).toMatchInlineSnapshot(`"sys"`);
+    expect(modifiedQuery).toMatchInlineSnapshot(`"sys"`);
   });
 
   it('renders getTableName', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -611,11 +611,11 @@ FROM sys.segments
 WHERE "size" = '12'
 GROUP BY 1,2
 ORDER BY "rank" DESC, "created_time" DESC`).getTableName();
-    expect(tree).toMatchInlineSnapshot(`"segments"`);
+    expect(modifiedQuery).toMatchInlineSnapshot(`"segments"`);
   });
 
   it('renders getAggregateColumns', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -628,7 +628,7 @@ FROM sys.segments
 WHERE "size" = '12'
 GROUP BY 1,2
 ORDER BY "rank" DESC, "created_time" DESC`).getAggregateColumns();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       Array [
         "num_available_segments",
         "size",
@@ -639,7 +639,7 @@ ORDER BY "rank" DESC, "created_time" DESC`).getAggregateColumns();
   });
 
   it('renders getColumnsArray', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -652,7 +652,7 @@ FROM sys.segments
 WHERE "size" = '12'
 GROUP BY 1,2
 ORDER BY "rank" DESC, "created_time" DESC`).getColumnsArray();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       Array [
         "datasource",
         "num_segments",
@@ -665,7 +665,7 @@ ORDER BY "rank" DESC, "created_time" DESC`).getColumnsArray();
   });
 
   it('renders toString', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -679,7 +679,7 @@ WHERE "size" = '12'
 GROUP BY 1,2
 ORDER BY "rank" DESC, "created_time" DESC`).toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         datasource,
         COUNT(*) AS num_segments,
@@ -699,7 +699,7 @@ ORDER BY "rank" DESC, "created_time" DESC`).toString();
 
 describe('Test how remove effect groupBy', () => {
   it('renders remove first of 2 columns', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -715,7 +715,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
       .excludeColumn('datasource')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         COUNT(*) AS num_segments,
         SUM(is_available) AS num_available_segments,
@@ -732,7 +732,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
   });
 
   it('renders remove second of 2 columns', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -748,7 +748,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
       .excludeColumn('num_segments')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         datasource,
         SUM(is_available) AS num_available_segments,
@@ -765,7 +765,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
   });
 
   it('renders remove first of 2 named columns', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -781,7 +781,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
       .excludeColumn('datasource')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         COUNT(*) AS num_segments,
         SUM(is_available) AS num_available_segments,
@@ -798,7 +798,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
   });
 
   it('renders remove second of 2 named columns', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -814,7 +814,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
       .excludeColumn('num_segments')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         datasource,
         SUM(is_available) AS num_available_segments,
@@ -831,7 +831,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
   });
 
   it('renders remove second of 1 of 1 columns', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -847,7 +847,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
       .excludeColumn('datasource')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         COUNT(*) AS num_segments,
         SUM(is_available) AS num_available_segments,
@@ -863,7 +863,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
   });
 
   it('renders remove second of 1 of 1 columns by index', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   datasource,
   COUNT(*) AS num_segments,
   SUM(is_available) AS num_available_segments,
@@ -879,7 +879,7 @@ ORDER BY "rank" DESC, "created_time" DESC`)
       .excludeColumn('datasource')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         COUNT(*) AS num_segments,
         SUM(is_available) AS num_available_segments,
@@ -895,32 +895,32 @@ ORDER BY "rank" DESC, "created_time" DESC`)
   });
 
   it('test basicIdentifierEscape', () => {
-    const tree = basicIdentifierEscape('header');
+    const modifiedQuery = basicIdentifierEscape('header');
 
-    expect(tree).toMatchInlineSnapshot(`"\\"header\\""`);
+    expect(modifiedQuery).toMatchInlineSnapshot(`"\\"header\\""`);
   });
 
   it('test basicLiteralEscape with string', () => {
-    const tree = basicLiteralEscape('row');
+    const modifiedQuery = basicLiteralEscape('row');
 
-    expect(tree).toMatchInlineSnapshot(`"'row'"`);
+    expect(modifiedQuery).toMatchInlineSnapshot(`"'row'"`);
   });
 
   it('test basicLiteralEscape with number', () => {
-    const tree = basicLiteralEscape(1);
+    const modifiedQuery = basicLiteralEscape(1);
 
-    expect(tree).toMatchInlineSnapshot(`"1"`);
+    expect(modifiedQuery).toMatchInlineSnapshot(`"1"`);
   });
 
   it('renders filter row with number', () => {
-    const tree = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
+    const modifiedQuery = parser(`SELECT "segment_id", "datasource", "start", "end", "size", "version", "partition_num", "num_replicas", "num_rows", "is_published", "is_available", "is_realtime", "is_overshadowed", "payload"
 FROM sys.segments
 ORDER BY "start" DESC
 LIMIT 25`)
       .filterRow('datasource', 1, '!=')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT \\"segment_id\\", \\"datasource\\", \\"start\\", \\"end\\", \\"size\\", \\"version\\", \\"partition_num\\", \\"num_replicas\\", \\"num_rows\\", \\"is_published\\", \\"is_available\\", \\"is_realtime\\", \\"is_overshadowed\\", \\"payload\\"
       FROM sys.segments
       WHERE \\"datasource\\" != 1
@@ -930,7 +930,7 @@ LIMIT 25`)
   });
 
   it('renders filter row with number', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "cityName",
   COUNT(*) AS "Count",
   SUM(added) AS "Added"
@@ -941,7 +941,7 @@ ORDER BY "Count" DESC`)
       .excludeColumn('Count')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         \\"cityName\\",
         SUM(added) AS \\"Added\\"
@@ -952,7 +952,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('renders filter aggregate row', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "cityName",
   COUNT(*) AS "Count",
   SUM(added) AS "Added"
@@ -963,7 +963,7 @@ ORDER BY "Count" DESC`)
       .filterRow('Count', 'value', '!=')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         \\"cityName\\",
         COUNT(*) AS \\"Count\\",
@@ -977,7 +977,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('renders filter aggregate row', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "cityName",
   COUNT(*) AS "Count",
   SUM(added) AS "Added"
@@ -988,7 +988,7 @@ ORDER BY "Count" DESC`)
       .filterRow('Count', 'value', '!=')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         \\"cityName\\",
         COUNT(*) AS \\"Count\\",
@@ -1002,7 +1002,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('renders  add to group by ', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "cityName",
   COUNT(*) AS "Count",
   SUM(added) AS "Added"
@@ -1013,7 +1013,7 @@ ORDER BY "Count" DESC`)
       .addToGroupBy('testValue')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         \\"testValue\\", \\"cityName\\",
         COUNT(*) AS \\"Count\\",
@@ -1026,7 +1026,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('renders add to group by for a second time ', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
     "somevalue",
   "cityName",
   COUNT(*) AS "Count",
@@ -1038,7 +1038,7 @@ ORDER BY "Count" DESC`)
       .addToGroupBy('testValue')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
           \\"testValue\\", \\"somevalue\\",
         \\"cityName\\",
@@ -1052,7 +1052,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('renders add to group by for a column already inside group by clause', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "user", "count", COUNT(*) AS "Count"
 FROM "wikipedia"
 GROUP BY 1,2
@@ -1060,7 +1060,7 @@ ORDER BY "Count" DESC`)
       .addToGroupBy('user')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         \\"user\\", \\"user\\", \\"count\\", COUNT(*) AS \\"Count\\"
       FROM \\"wikipedia\\"
@@ -1070,7 +1070,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('renders  add to group by out of order', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   COUNT(*) AS "Count",
     "cityName",
   SUM(added) AS "Added"
@@ -1081,7 +1081,7 @@ ORDER BY "Count" DESC`)
       .addToGroupBy('testValue')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         \\"testValue\\", COUNT(*) AS \\"Count\\",
           \\"cityName\\",
@@ -1094,7 +1094,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('renders  add to group by out of no groupby, Should not change', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   COUNT(*) AS "Count",
     "cityName",
   SUM(added) AS "Added"
@@ -1104,7 +1104,7 @@ ORDER BY "Count" DESC`)
       .addToGroupBy('testValue')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         COUNT(*) AS \\"Count\\",
           \\"cityName\\",
@@ -1131,7 +1131,7 @@ ORDER BY "Count" DESC`).getGroupByColumns();
   });
 
   it('remove first column in group by', () => {
-    const parsedQuery = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "page", "count", "user",
   COUNT(*) AS "Count"
 FROM "wikipedia"
@@ -1140,7 +1140,7 @@ ORDER BY "Count" DESC`)
       .removeGroupBy('page')
       .toString();
 
-    expect(parsedQuery).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         \\"count\\", \\"user\\", COUNT(*) AS \\"Count\\"
       FROM \\"wikipedia\\"
@@ -1150,7 +1150,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('remove second column in group by', () => {
-    const parsedQuery = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "page", "count", "user",
   COUNT(*) AS "Count"
 FROM "wikipedia"
@@ -1159,7 +1159,7 @@ ORDER BY "Count" DESC`)
       .removeGroupBy('count')
       .toString();
 
-    expect(parsedQuery).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         \\"page\\", \\"user\\", COUNT(*) AS \\"Count\\"
       FROM \\"wikipedia\\"
@@ -1169,7 +1169,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('remove third column in group by', () => {
-    const parsedQuery = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "page", "count", "user",
   COUNT(*) AS "Count"
 FROM "wikipedia"
@@ -1178,7 +1178,7 @@ ORDER BY "Count" DESC`)
       .removeGroupBy('user')
       .toString();
 
-    expect(parsedQuery).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         \\"page\\", \\"count\\", COUNT(*) AS \\"Count\\"
       FROM \\"wikipedia\\"
@@ -1188,7 +1188,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('remove string column in group by mixed with names and indexes', () => {
-    const parsedQuery = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "page", "count", "user",
   COUNT(*) AS "Count"
 FROM "wikipedia"
@@ -1197,7 +1197,7 @@ ORDER BY "Count" DESC`)
       .removeGroupBy('count')
       .toString();
 
-    expect(parsedQuery).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         \\"page\\", \\"user\\", COUNT(*) AS \\"Count\\"
       FROM \\"wikipedia\\"
@@ -1207,7 +1207,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('remove index column in group by mixed with names and indexes', () => {
-    const parsedQuery = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "page", "count", "user",
   COUNT(*) AS "Count"
 FROM "wikipedia"
@@ -1216,7 +1216,7 @@ ORDER BY "Count" DESC`)
       .removeGroupBy('user')
       .toString();
 
-    expect(parsedQuery).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         \\"page\\", \\"count\\", COUNT(*) AS \\"Count\\"
       FROM \\"wikipedia\\"
@@ -1226,7 +1226,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('remove only column in group by', () => {
-    const parsedQuery = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "page",
   COUNT(*) AS "Count"
 FROM "wikipedia"
@@ -1235,7 +1235,7 @@ ORDER BY "Count" DESC`)
       .removeGroupBy('page')
       .toString();
 
-    expect(parsedQuery).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         COUNT(*) AS \\"Count\\"
       FROM \\"wikipedia\\"
@@ -1244,7 +1244,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('remove most recent column in group by when it occurs multiple times', () => {
-    const parsedQuery = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "user", "countryIsoCode", "user", COUNT(*) AS "Count"
 FROM "wikipedia"
 GROUP BY 1,2,3
@@ -1252,7 +1252,7 @@ ORDER BY "Count" DESC`)
       .removeGroupBy('user')
       .toString();
 
-    expect(parsedQuery).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         \\"user\\", \\"countryIsoCode\\", COUNT(*) AS \\"Count\\"
       FROM \\"wikipedia\\"
@@ -1262,7 +1262,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('remove most recent column in group by when it occurs multiple times and it is grouped by name', () => {
-    const parsedQuery = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "user", "countryIsoCode", "user", COUNT(*) AS "Count"
 FROM "wikipedia"
 GROUP BY 1,2,user
@@ -1270,7 +1270,7 @@ ORDER BY "Count" DESC`)
       .removeGroupBy('user')
       .toString();
 
-    expect(parsedQuery).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         \\"user\\", \\"countryIsoCode\\", COUNT(*) AS \\"Count\\"
       FROM \\"wikipedia\\"
@@ -1280,7 +1280,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('remove most recent column in group by when it occurs multiple times and it is an index', () => {
-    const parsedQuery = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "user", "countryIsoCode", "user", COUNT(*) AS "Count"
 FROM "wikipedia"
 GROUP BY user,2,3
@@ -1288,7 +1288,7 @@ ORDER BY "Count" DESC`)
       .removeGroupBy('user')
       .toString();
 
-    expect(parsedQuery).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         \\"user\\", \\"countryIsoCode\\", COUNT(*) AS \\"Count\\"
       FROM \\"wikipedia\\"
@@ -1298,7 +1298,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('remove column in group by mixed with non group by columns', () => {
-    const parsedQuery = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "countryIsoCode", COUNT(*) AS "Count", "cityName", SUM(sum_added) AS "Added"
 FROM "wikipedia"
 GROUP BY 1,3
@@ -1306,7 +1306,7 @@ ORDER BY "Count" DESC`)
       .removeGroupBy('countryIsoCode')
       .toString();
 
-    expect(parsedQuery).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         COUNT(*) AS \\"Count\\", \\"cityName\\", SUM(sum_added) AS \\"Added\\"
       FROM \\"wikipedia\\"
@@ -1316,7 +1316,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('renders  add aggregate column', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "cityName",
   COUNT(*) AS "Count",
   SUM(added) AS "Added"
@@ -1327,7 +1327,7 @@ ORDER BY "Count" DESC`)
       .addAggregateColumn('testValue', 'SUM')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         \\"cityName\\",
         COUNT(*) AS \\"Count\\",
@@ -1340,7 +1340,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('renders  add function to Groupby', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "cityName",
   COUNT(*) AS "Count",
   SUM(added) AS "Added"
@@ -1351,7 +1351,7 @@ ORDER BY "Count" DESC`)
       .addFunctionToGroupBy('TRUNCATE', [' ', ' '], ['added', 1])
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TRUNCATE(added, 1), \\"cityName\\",
         COUNT(*) AS \\"Count\\",
@@ -1387,7 +1387,7 @@ ORDER BY "Count" DESC`)
       spacing: [' ', ' '],
     });
 
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "cityName",
   COUNT(*) AS "Count",
   SUM(added) AS "Added"
@@ -1397,7 +1397,7 @@ ORDER BY "Count" DESC`)
       .filterRow(additiveExpression, 'columnName', '>=')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         \\"cityName\\",
         COUNT(*) AS \\"Count\\",
@@ -1409,7 +1409,7 @@ ORDER BY "Count" DESC`)
     `);
   });
   it('renders filter by additive ex', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   "cityName",
   COUNT(*) AS "Count",
   SUM(added) AS "Added"
@@ -1431,7 +1431,7 @@ ORDER BY "Count" DESC`)
       )
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         \\"cityName\\",
         COUNT(*) AS \\"Count\\",
@@ -1442,7 +1442,7 @@ ORDER BY "Count" DESC`)
     `);
   });
   it('renders filter by additive ex', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
     "cityName",
     COUNT(*) AS "Count",
     SUM(added) AS "Added"
@@ -1465,7 +1465,7 @@ ORDER BY "Count" DESC`)
       )
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
           \\"cityName\\",
           COUNT(*) AS \\"Count\\",
@@ -1476,7 +1476,7 @@ ORDER BY "Count" DESC`)
     `);
   });
   it('renders filter by additive ex', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
     "cityName",
     COUNT(*) AS "Count",
     SUM(added) AS "Added"
@@ -1510,7 +1510,7 @@ ORDER BY "Count" DESC`)
       )
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
           \\"cityName\\",
           COUNT(*) AS \\"Count\\",
@@ -1522,7 +1522,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('renders filter by additive ex', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
     "cityName",
     COUNT(*) AS "Count",
     SUM(added) AS "Added"
@@ -1534,7 +1534,7 @@ ORDER BY "Count" DESC`)
       .filterRow('name', timestampFactory('2018-08-8'), '>=')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
           \\"cityName\\",
           COUNT(*) AS \\"Count\\",
@@ -1547,7 +1547,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('test applying actions to inner query', () => {
-    const tree = parser(`
+    const modifiedQuery = parser(`
     SELECT * FROM (
     SELECT
     "cityName",
@@ -1560,7 +1560,7 @@ ORDER BY "Count" DESC;)`)
       .filterRow(timestampFactory('2018-08-8'), 'name', '>=')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "
           SELECT * FROM (
           SELECT
@@ -1575,7 +1575,7 @@ ORDER BY "Count" DESC;)`)
   });
 
   it('renders filter by additive ex', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
     "cityName",
     COUNT(*) AS "Count",
     SUM(added) AS "Added"
@@ -1586,7 +1586,7 @@ ORDER BY "Count" DESC`)
       .filterRow('name', timestampFactory('2018-08-8'), '>=')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
           \\"cityName\\",
           COUNT(*) AS \\"Count\\",
@@ -1599,7 +1599,7 @@ ORDER BY "Count" DESC`)
   });
 
   it('renders filter by additive ex', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   SUBSTRING("org", 1, 2), TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "github"
@@ -1607,7 +1607,7 @@ WHERE "__time" >= CURRENT_TIMESTAMP - INTERVAL '1' DAY
 GROUP BY 1,2
 ORDER BY "Time" ASC`).toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         SUBSTRING(\\"org\\", 1, 2), TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -1619,7 +1619,7 @@ ORDER BY "Time" ASC`).toString();
   });
 
   it('renders filter by additive ex', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -1634,7 +1634,7 @@ ORDER BY "Time" ASC`)
       )
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         SUBSTRING(\\"test\\", 0, 2) AS \\"__test-substring\\", TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -1648,7 +1648,7 @@ ORDER BY "Time" ASC`)
 
 describe('Test getting current filters and removing specific filters', () => {
   it('get simple current filter', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -1656,7 +1656,7 @@ WHERE "__time" >= 'value'
 GROUP BY 1
 ORDER BY "Time" ASC`).getCurrentFilters();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       Array [
         "__time",
       ]
@@ -1664,7 +1664,7 @@ ORDER BY "Time" ASC`).getCurrentFilters();
   });
 
   it('get simple current filter with expression', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -1672,7 +1672,7 @@ WHERE "__time" >= CURRENT_TIMESTAMP - INTERVAL '1' DAY
 GROUP BY 1
 ORDER BY "Time" ASC`).getCurrentFilters();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       Array [
         "__time",
       ]
@@ -1680,7 +1680,7 @@ ORDER BY "Time" ASC`).getCurrentFilters();
   });
 
   it('get simple current filter with backwards expression', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -1688,7 +1688,7 @@ WHERE CURRENT_TIMESTAMP - INTERVAL '1' DAY >= "__time"
 GROUP BY 1
 ORDER BY "Time" ASC`).getCurrentFilters();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       Array [
         "__time",
       ]
@@ -1696,7 +1696,7 @@ ORDER BY "Time" ASC`).getCurrentFilters();
   });
 
   it('get current filter with multiple simple expressions', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -1704,7 +1704,7 @@ WHERE "__time" >= 'value' AND "__time2" >= 'value2' AND "__time3" >= 'value3'
 GROUP BY 1
 ORDER BY "Time" ASC`).getCurrentFilters();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       Array [
         "__time",
         "__time2",
@@ -1714,7 +1714,7 @@ ORDER BY "Time" ASC`).getCurrentFilters();
   });
 
   it('get current filter with multiple expressions', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -1722,7 +1722,7 @@ WHERE "__time" >= CURRENT_TIMESTAMP - INTERVAL '1' DAY AND CURRENT_TIMESTAMP - I
 GROUP BY 1
 ORDER BY "Time" ASC`).getCurrentFilters();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       Array [
         "__time",
         "__time",
@@ -1732,7 +1732,7 @@ ORDER BY "Time" ASC`).getCurrentFilters();
   });
 
   it('remove current filter with single simple expression', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -1742,7 +1742,7 @@ ORDER BY "Time" ASC`)
       .removeFilter('__time')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -1753,7 +1753,7 @@ ORDER BY "Time" ASC`)
   });
 
   it('remove current filter with backwards simple expression', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -1763,7 +1763,7 @@ ORDER BY "Time" ASC`)
       .removeFilter('__time')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -1774,7 +1774,7 @@ ORDER BY "Time" ASC`)
   });
 
   it('remove current filter with no matching expression', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -1784,7 +1784,7 @@ ORDER BY "Time" ASC`)
       .removeFilter('__time')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -1796,7 +1796,7 @@ ORDER BY "Time" ASC`)
   });
 
   it('remove current filter with multiple simple & backwards expressions', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -1805,7 +1805,7 @@ GROUP BY 1
 ORDER BY "Time" ASC`)
       .removeFilter('value2')
       .toString();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -1817,7 +1817,7 @@ ORDER BY "Time" ASC`)
   });
 
   it('remove one of two filters', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -1826,7 +1826,7 @@ GROUP BY 1
 ORDER BY "Time" ASC`)
       .removeFilter('value2')
       .toString();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -1838,7 +1838,7 @@ ORDER BY "Time" ASC`)
   });
 
   it('remove time stamp', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "flow0"
@@ -1847,7 +1847,7 @@ GROUP BY 1
 ORDER BY "Time" ASC`)
       .removeFilter('__time')
       .toString();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -1858,7 +1858,7 @@ ORDER BY "Time" ASC`)
   });
 
   it('remove time stamp', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "flow0"
@@ -1867,7 +1867,7 @@ GROUP BY 1
 ORDER BY "Time" ASC`)
       .removeFilter('__time')
       .toString();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -1879,7 +1879,7 @@ ORDER BY "Time" ASC`)
   });
 
   it('remove whereClause', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "flow0"
@@ -1888,7 +1888,7 @@ GROUP BY 1
 ORDER BY "Time" ASC`)
       .removeFilter('__time')
       .toString();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -1899,7 +1899,7 @@ ORDER BY "Time" ASC`)
   });
 
   it('get simple current filter', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -1907,7 +1907,7 @@ WHERE __time >= 'value'
 GROUP BY 1
 ORDER BY "Time" ASC`).getCurrentFilters();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       Array [
         "__time",
       ]
@@ -1915,7 +1915,7 @@ ORDER BY "Time" ASC`).getCurrentFilters();
   });
 
   it('get simple current filter with expression', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -1923,7 +1923,7 @@ WHERE __time >= CURRENT_TIMESTAMP - INTERVAL '1' DAY
 GROUP BY 1
 ORDER BY "Time" ASC`).getCurrentFilters();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       Array [
         "__time",
       ]
@@ -1931,7 +1931,7 @@ ORDER BY "Time" ASC`).getCurrentFilters();
   });
 
   it('get simple current filter with backwards expression', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -1939,7 +1939,7 @@ WHERE CURRENT_TIMESTAMP - INTERVAL '1' DAY >= __time
 GROUP BY 1
 ORDER BY "Time" ASC`).getCurrentFilters();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       Array [
         "__time",
       ]
@@ -1947,7 +1947,7 @@ ORDER BY "Time" ASC`).getCurrentFilters();
   });
 
   it('get current filter with multiple simple expressions', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -1955,7 +1955,7 @@ WHERE "__time" >= 'value' AND "__time2" >= 'value2' AND __timeThree >= 'value3'
 GROUP BY 1
 ORDER BY "Time" ASC`).getCurrentFilters();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       Array [
         "__time",
         "__time2",
@@ -1965,7 +1965,7 @@ ORDER BY "Time" ASC`).getCurrentFilters();
   });
 
   it('get current filter with multiple expressions', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -1973,7 +1973,7 @@ WHERE __time >= CURRENT_TIMESTAMP - INTERVAL '1' DAY AND CURRENT_TIMESTAMP - INT
 GROUP BY 1
 ORDER BY "Time" ASC`).getCurrentFilters();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       Array [
         "__time",
         "__time",
@@ -1983,7 +1983,7 @@ ORDER BY "Time" ASC`).getCurrentFilters();
   });
 
   it('remove current filter with single simple expression', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -1993,7 +1993,7 @@ ORDER BY "Time" ASC`)
       .removeFilter('__time')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -2004,7 +2004,7 @@ ORDER BY "Time" ASC`)
   });
 
   it('remove current filter with backwards simple expression', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -2014,7 +2014,7 @@ ORDER BY "Time" ASC`)
       .removeFilter('__time')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -2025,7 +2025,7 @@ ORDER BY "Time" ASC`)
   });
 
   it('remove current filter with no matching expression', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -2035,7 +2035,7 @@ ORDER BY "Time" ASC`)
       .removeFilter('__time')
       .toString();
 
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -2047,7 +2047,7 @@ ORDER BY "Time" ASC`)
   });
 
   it('remove current filter with multiple simple & backwards expressions', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -2056,7 +2056,7 @@ GROUP BY 1
 ORDER BY "Time" ASC`)
       .removeFilter('valueTwo')
       .toString();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -2068,7 +2068,7 @@ ORDER BY "Time" ASC`)
   });
 
   it('remove one of two filters', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "lineitem"
@@ -2077,7 +2077,7 @@ GROUP BY 1
 ORDER BY "Time" ASC`)
       .removeFilter('value2')
       .toString();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -2089,7 +2089,7 @@ ORDER BY "Time" ASC`)
   });
 
   it('remove time stamp', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "flow0"
@@ -2098,7 +2098,7 @@ GROUP BY 1
 ORDER BY "Time" ASC`)
       .removeFilter('__time')
       .toString();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -2109,7 +2109,7 @@ ORDER BY "Time" ASC`)
   });
 
   it('remove time stamp', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "flow0"
@@ -2118,7 +2118,7 @@ GROUP BY 1
 ORDER BY "Time" ASC`)
       .removeFilter('__time')
       .toString();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -2131,7 +2131,7 @@ ORDER BY "Time" ASC`)
 });
 describe('Replace from', () => {
   it('replace with no namespace', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "flow0"
@@ -2140,7 +2140,7 @@ GROUP BY 1
 ORDER BY "Time" ASC`)
       .replaceFrom(refExpressionFactory('test'))
       .toString();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -2152,7 +2152,7 @@ ORDER BY "Time" ASC`)
   });
 
   it('replace with namespace', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "flow0"
@@ -2161,7 +2161,7 @@ GROUP BY 1
 ORDER BY "Time" ASC`)
       .replaceFrom(refExpressionFactory('test', 'test'))
       .toString();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"
@@ -2173,7 +2173,7 @@ ORDER BY "Time" ASC`)
   });
 
   it('replace with quotes', () => {
-    const tree = parser(`SELECT
+    const modifiedQuery = parser(`SELECT
   TIME_FLOOR("__time", 'PT1H') AS "Time",
   COUNT(*) AS "Count"
 FROM "flow0"
@@ -2182,7 +2182,7 @@ GROUP BY 1
 ORDER BY "Time" ASC`)
       .replaceFrom(refExpressionFactory(stringFactory('test', '"')))
       .toString();
-    expect(tree).toMatchInlineSnapshot(`
+    expect(modifiedQuery).toMatchInlineSnapshot(`
       "SELECT
         TIME_FLOOR(\\"__time\\", 'PT1H') AS \\"Time\\",
         COUNT(*) AS \\"Count\\"

--- a/src/actions.spec.ts
+++ b/src/actions.spec.ts
@@ -1187,6 +1187,23 @@ ORDER BY "Count" DESC`)
       ORDER BY \\"Count\\" DESC"
     `);
   });
+  it('remove only column in group by', () => {
+    const tree = parser(`SELECT
+  "page",
+  COUNT(*) AS "Count"
+FROM "wikipedia"
+GROUP BY 1
+ORDER BY "Count" DESC`)
+      .removeGroupBy('page')
+      .toString();
+
+    expect(tree).toMatchInlineSnapshot(`
+      "SELECT
+        COUNT(*) AS \\"Count\\"
+      FROM \\"wikipedia\\"
+      ORDER BY \\"Count\\" DESC"
+    `);
+  });
   it('renders  add aggregate column', () => {
     const tree = parser(`SELECT
   "cityName",

--- a/src/actions.spec.ts
+++ b/src/actions.spec.ts
@@ -518,6 +518,21 @@ ORDER BY "rank" DESC, "created_time" DESC`)
     `);
   });
 
+  it('ensures commas are prevalent to separate arguments in a function', () => {
+    const modifiedQuery = parser(`select TIME_EXTRACT(__time,'HOUR') AS _hour_of_day, COUNT(1) AS _count
+FROM wikipedia 
+GROUP BY 1`)
+      .orderBy('_hour_of_day', 'DESC')
+      .toString();
+
+    expect(modifiedQuery).toMatchInlineSnapshot(`
+      "SELECT TIME_EXTRACT(__time,'HOUR') AS _hour_of_day, COUNT(1) AS _count
+      FROM wikipedia 
+      GROUP BY 1
+      ORDER BY \\"_hour_of_day\\" DESC"
+    `);
+  });
+
   it('renders exclude row', () => {
     const modifiedQuery = parser(`SELECT
   datasource,

--- a/src/actions.spec.ts
+++ b/src/actions.spec.ts
@@ -1096,7 +1096,97 @@ ORDER BY "Count" DESC`)
       ORDER BY \\"Count\\" DESC"
     `);
   });
+  it('remove first column in group by', () => {
+    const tree = parser(`SELECT
+  "page", "count", "user",
+  COUNT(*) AS "Count"
+FROM "wikipedia"
+GROUP BY 1,2,3
+ORDER BY "Count" DESC`)
+      .removeGroupBy('page')
+      .toString();
 
+    expect(tree).toMatchInlineSnapshot(`
+      "SELECT
+        \\"count\\", \\"user\\", COUNT(*) AS \\"Count\\"
+      FROM \\"wikipedia\\"
+      GROUP BY 1,2
+      ORDER BY \\"Count\\" DESC"
+    `);
+  });
+
+  it('remove second column in group by', () => {
+    const tree = parser(`SELECT
+  "page", "count", "user",
+  COUNT(*) AS "Count"
+FROM "wikipedia"
+GROUP BY 1,2,3
+ORDER BY "Count" DESC`)
+      .removeGroupBy('count')
+      .toString();
+
+    expect(tree).toMatchInlineSnapshot(`
+      "SELECT
+        \\"page\\", \\"user\\", COUNT(*) AS \\"Count\\"
+      FROM \\"wikipedia\\"
+      GROUP BY 1,2
+      ORDER BY \\"Count\\" DESC"
+    `);
+  });
+  it('remove third column in group by', () => {
+    const tree = parser(`SELECT
+  "page", "count", "user",
+  COUNT(*) AS "Count"
+FROM "wikipedia"
+GROUP BY 1,2,3
+ORDER BY "Count" DESC`)
+      .removeGroupBy('user')
+      .toString();
+
+    expect(tree).toMatchInlineSnapshot(`
+      "SELECT
+        \\"page\\", \\"count\\", COUNT(*) AS \\"Count\\"
+      FROM \\"wikipedia\\"
+      GROUP BY 1,2
+      ORDER BY \\"Count\\" DESC"
+    `);
+  });
+  it('remove string column in group by mixed with names and indexes', () => {
+    const tree = parser(`SELECT
+  "page", "count", "user",
+  COUNT(*) AS "Count"
+FROM "wikipedia"
+GROUP BY 1,count,3
+ORDER BY "Count" DESC`)
+      .removeGroupBy('count')
+      .toString();
+
+    expect(tree).toMatchInlineSnapshot(`
+      "SELECT
+        \\"page\\", \\"user\\", COUNT(*) AS \\"Count\\"
+      FROM \\"wikipedia\\"
+      GROUP BY 1,2
+      ORDER BY \\"Count\\" DESC"
+    `);
+  });
+  it('remove index column in group by mixed with names and indexes', () => {
+    const tree = parser(`SELECT
+  "page", "count", "user",
+  COUNT(*) AS "Count"
+FROM "wikipedia"
+GROUP BY 1,count,3
+ORDER BY "Count" DESC`)
+      .removeGroupBy('user')
+      .toString();
+
+    expect(tree).toMatchInlineSnapshot(`
+      "SELECT
+        \\"page\\", \\"count\\", COUNT(*) AS \\"Count\\"
+      FROM \\"wikipedia\\"
+      GROUP BY 1,count
+      ORDER BY \\"Count\\" DESC"
+    `);
+  });
   it('renders  add aggregate column', () => {
     const tree = parser(`SELECT
   "cityName",

--- a/src/actions.spec.ts
+++ b/src/actions.spec.ts
@@ -1261,6 +1261,42 @@ ORDER BY "Count" DESC`)
     `);
   });
 
+  it('remove most recent column in group by when it occurs multiple times and it is grouped by name', () => {
+    const parsedQuery = parser(`SELECT
+  "user", "countryIsoCode", "user", COUNT(*) AS "Count"
+FROM "wikipedia"
+GROUP BY 1,2,user
+ORDER BY "Count" DESC`)
+      .removeGroupBy('user')
+      .toString();
+
+    expect(parsedQuery).toMatchInlineSnapshot(`
+      "SELECT
+        \\"user\\", \\"countryIsoCode\\", COUNT(*) AS \\"Count\\"
+      FROM \\"wikipedia\\"
+      GROUP BY 1,2
+      ORDER BY \\"Count\\" DESC"
+    `);
+  });
+
+  it('remove most recent column in group by when it occurs multiple times and it is an index', () => {
+    const parsedQuery = parser(`SELECT
+  "user", "countryIsoCode", "user", COUNT(*) AS "Count"
+FROM "wikipedia"
+GROUP BY user,2,3
+ORDER BY "Count" DESC`)
+      .removeGroupBy('user')
+      .toString();
+
+    expect(parsedQuery).toMatchInlineSnapshot(`
+      "SELECT
+        \\"user\\", \\"countryIsoCode\\", COUNT(*) AS \\"Count\\"
+      FROM \\"wikipedia\\"
+      GROUP BY user,2
+      ORDER BY \\"Count\\" DESC"
+    `);
+  });
+
   it('remove column in group by mixed with non group by columns', () => {
     const parsedQuery = parser(`SELECT
   "countryIsoCode", COUNT(*) AS "Count", "cityName", SUM(sum_added) AS "Added"

--- a/src/actions.spec.ts
+++ b/src/actions.spec.ts
@@ -1204,6 +1204,23 @@ ORDER BY "Count" DESC`)
       ORDER BY \\"Count\\" DESC"
     `);
   });
+  it('remove column in group by mixed with non group by columns', () => {
+    const tree = parser(`SELECT
+  "countryIsoCode", COUNT(*) AS "Count", "cityName", SUM(sum_added) AS "Added"
+FROM "wikipedia"
+GROUP BY 1,3
+ORDER BY "Count" DESC`)
+      .removeGroupBy('countryIsoCode')
+      .toString();
+
+    expect(tree).toMatchInlineSnapshot(`
+      "SELECT
+        COUNT(*) AS \\"Count\\", \\"cityName\\", SUM(sum_added) AS \\"Added\\"
+      FROM \\"wikipedia\\"
+      GROUP BY 2
+      ORDER BY \\"Count\\" DESC"
+    `);
+  });
   it('renders  add aggregate column', () => {
     const tree = parser(`SELECT
   "cityName",

--- a/src/actions.spec.ts
+++ b/src/actions.spec.ts
@@ -1096,6 +1096,21 @@ ORDER BY "Count" DESC`)
       ORDER BY \\"Count\\" DESC"
     `);
   });
+
+  it('get current group by columns', () => {
+    const tree = parser(`SELECT
+  "countryIsoCode", COUNT(*) AS "Count", "cityName", SUM(sum_added) AS "Added"
+FROM "wikipedia"
+GROUP BY 1,"cityName"
+ORDER BY "Count" DESC`).getGroupByColumns();
+
+    expect(tree).toMatchInlineSnapshot(`
+      Array [
+        "countryIsoCode",
+        "cityName",
+      ]
+    `);
+  });
   it('remove first column in group by', () => {
     const tree = parser(`SELECT
   "page", "count", "user",

--- a/src/ast/sql-query/basic-expression/function-call/function.ts
+++ b/src/ast/sql-query/basic-expression/function-call/function.ts
@@ -67,8 +67,9 @@ export class Function {
       }
       this.value.map((value, index: number) => {
         val.push(value instanceof OrExpression ? value.toString() : value);
-        if (index < this.value.length - 1 && this.argumentSpacing[index]) {
-          val.push(',' + this.argumentSpacing[index]);
+        if (index < this.value.length - 1) {
+          val.push(',');
+          val.push(this.argumentSpacing[index] !== null ? this.argumentSpacing[index] : '');
         }
       });
     }

--- a/src/ast/sql-query/sql-query.ts
+++ b/src/ast/sql-query/sql-query.ts
@@ -327,12 +327,15 @@ export class SqlQuery extends BaseAst {
       withClause: this.withClause,
       distinct: this.distinct,
       fromClause: this.fromClause,
-      groupByClause: new GroupByClause({
-        groupKeyword: this.groupByClause.groupKeyword,
-        byKeyword: this.groupByClause.byKeyword,
-        groupBy: newGroupBy,
-        spacing: this.groupByClause.spacing,
-      }),
+      groupByClause:
+        newGroupBy.length > 0
+          ? new GroupByClause({
+              groupKeyword: this.groupByClause.groupKeyword,
+              byKeyword: this.groupByClause.byKeyword,
+              groupBy: newGroupBy,
+              spacing: this.groupByClause.spacing,
+            })
+          : undefined,
       havingClause: this.havingClause,
       limitClause: this.limitClause,
       orderByClause: this.orderByClause,

--- a/src/ast/sql-query/sql-query.ts
+++ b/src/ast/sql-query/sql-query.ts
@@ -243,7 +243,7 @@ export class SqlQuery extends BaseAst {
       }
     }
 
-    if (!this.groupByClause || this.hasGroupByForColumn(columnName)) {
+    if (!this.groupByClause) {
       return this;
     }
 
@@ -289,10 +289,9 @@ export class SqlQuery extends BaseAst {
     const groupByColumnNames: string[] = [];
     const groupByColumns = this.groupByClause.groupBy.map(part => part.getBasicValue());
     this.columns.columns.forEach((column, index) => {
-      index = index + 1;
       if (
         arrayContains(column.getBasicValue(), groupByColumns) ||
-        arrayContains(String(index), groupByColumns)
+        arrayContains(String(index + 1), groupByColumns)
       ) {
         groupByColumnNames.push(column.getBasicValue());
       }
@@ -300,28 +299,43 @@ export class SqlQuery extends BaseAst {
 
     return groupByColumnNames;
   }
+
   removeGroupBy(columnName: string): SqlQuery {
     if (!this.groupByClause) return this;
     const newColumns: Column[] = [];
     const columnSpacing = this.columns.spacing;
+    const columns = this.columns.columns;
+    const indexOfColumn = this.getColumnsArray().lastIndexOf(columnName);
 
     // Remove column from select
-    this.columns.columns.forEach(column => {
-      if (column.getBasicValue() !== columnName) newColumns.push(column);
+    columns.forEach((column, index) => {
+      if (indexOfColumn !== index) newColumns.push(column);
     });
 
     // Remove column from group by
     const groupByColumns = this.groupByClause.groupBy.map(part => part.getBasicValue());
     const newGroupBy: any[] = [];
-    groupByColumns.forEach(groupByColumn => {
-      if (columnName !== groupByColumn) {
-        if (this.getColumnsArray().indexOf(columnName) + 1 < Number(groupByColumn)) {
+
+    if (groupByColumns.lastIndexOf(columnName) === -1) {
+      groupByColumns.forEach(groupByColumn => {
+        if (indexOfColumn + 1 < Number(groupByColumn)) {
           newGroupBy.push(Number(groupByColumn - 1));
-        } else if (this.getColumnsArray().indexOf(columnName) + 1 !== Number(groupByColumn)) {
+        } else if (indexOfColumn + 1 !== Number(groupByColumn)) {
           newGroupBy.push(groupByColumn);
         }
-      }
-    });
+      });
+    } else {
+      groupByColumns.forEach(groupByColumn => {
+        if (groupByColumns.lastIndexOf(columnName) + 1 < Number(groupByColumn)) {
+          newGroupBy.push(Number(groupByColumn - 1));
+        } else if (
+          groupByColumns.lastIndexOf(columnName) + 1 !== groupByColumn &&
+          groupByColumn !== columnName
+        ) {
+          newGroupBy.push(groupByColumn);
+        }
+      });
+    }
     return new SqlQuery({
       columns: new Columns({ columns: newColumns, parens: [], spacing: columnSpacing }),
       withClause: this.withClause,
@@ -344,6 +358,7 @@ export class SqlQuery extends BaseAst {
       whereClause: this.whereClause,
     });
   }
+
   addAggregateColumn(
     columnName: string | RefExpression,
     functionName: string,

--- a/src/ast/sql-query/sql-query.ts
+++ b/src/ast/sql-query/sql-query.ts
@@ -243,7 +243,7 @@ export class SqlQuery extends BaseAst {
       }
     }
 
-    if (!this.groupByClause) {
+    if (!this.groupByClause || this.hasGroupByForColumn(columnName)) {
       return this;
     }
 

--- a/src/ast/sql-query/sql-query.ts
+++ b/src/ast/sql-query/sql-query.ts
@@ -317,7 +317,7 @@ export class SqlQuery extends BaseAst {
       if (columnName !== groupByColumn) {
         if (this.getColumnsArray().indexOf(columnName) + 1 < Number(groupByColumn)) {
           newGroupBy.push(Number(groupByColumn - 1));
-        } else if (this.getColumnsArray().indexOf(columnName) + 1 > Number(groupByColumn)) {
+        } else if (this.getColumnsArray().indexOf(columnName) + 1 !== Number(groupByColumn)) {
           newGroupBy.push(groupByColumn);
         }
       }

--- a/src/ast/sql-query/sql-query.ts
+++ b/src/ast/sql-query/sql-query.ts
@@ -314,28 +314,39 @@ export class SqlQuery extends BaseAst {
 
     // Remove column from group by
     const groupByColumns = this.groupByClause.groupBy.map(part => part.getBasicValue());
+    const groupByColumnNames = this.getGroupByColumns();
+    const indexToRemove = groupByColumnNames.lastIndexOf(columnName);
     const newGroupBy: any[] = [];
 
-    if (groupByColumns.lastIndexOf(columnName) === -1) {
-      groupByColumns.forEach(groupByColumn => {
-        if (indexOfColumn + 1 < Number(groupByColumn)) {
+    groupByColumns.forEach((groupByColumn, index) => {
+      if (index !== indexToRemove) {
+        if (indexToRemove + 1 < Number(groupByColumn)) {
           newGroupBy.push(Number(groupByColumn - 1));
-        } else if (indexOfColumn + 1 !== Number(groupByColumn)) {
-          newGroupBy.push(groupByColumn);
-        }
-      });
-    } else {
-      groupByColumns.forEach(groupByColumn => {
-        if (groupByColumns.lastIndexOf(columnName) + 1 < Number(groupByColumn)) {
-          newGroupBy.push(Number(groupByColumn - 1));
-        } else if (
-          groupByColumns.lastIndexOf(columnName) + 1 !== groupByColumn &&
-          groupByColumn !== columnName
-        ) {
-          newGroupBy.push(groupByColumn);
-        }
-      });
-    }
+        } else if (this.groupByClause) newGroupBy.push(this.groupByClause.groupBy[index]);
+      }
+    });
+    // if (groupByColumns.lastIndexOf(columnName) === -1) {
+    //   // if the column is an index
+    //   groupByColumns.forEach(groupByColumn => {
+    //     if (indexOfColumn + 1 < Number(groupByColumn)) {
+    //       newGroupBy.push(Number(groupByColumn - 1));
+    //     } else if (indexOfColumn + 1 !== Number(groupByColumn)) {
+    //       newGroupBy.push(groupByColumn);
+    //     }
+    //   });
+    // } else {
+    //   groupByColumns.forEach(groupByColumn => {
+    //     if (groupByColumns.lastIndexOf(columnName) + 1 < Number(groupByColumn)) {
+    //       newGroupBy.push(Number(groupByColumn - 1));
+    //     } else if (
+    //       groupByColumns.lastIndexOf(columnName) + 1 !== groupByColumn &&
+    //       groupByColumn !== columnName
+    //     ) {
+    //       newGroupBy.push(groupByColumn);
+    //     }
+    //   });
+    // }
+
     return new SqlQuery({
       columns: new Columns({ columns: newColumns, parens: [], spacing: columnSpacing }),
       withClause: this.withClause,

--- a/src/ast/sql-query/sql-query.ts
+++ b/src/ast/sql-query/sql-query.ts
@@ -325,27 +325,6 @@ export class SqlQuery extends BaseAst {
         } else if (this.groupByClause) newGroupBy.push(this.groupByClause.groupBy[index]);
       }
     });
-    // if (groupByColumns.lastIndexOf(columnName) === -1) {
-    //   // if the column is an index
-    //   groupByColumns.forEach(groupByColumn => {
-    //     if (indexOfColumn + 1 < Number(groupByColumn)) {
-    //       newGroupBy.push(Number(groupByColumn - 1));
-    //     } else if (indexOfColumn + 1 !== Number(groupByColumn)) {
-    //       newGroupBy.push(groupByColumn);
-    //     }
-    //   });
-    // } else {
-    //   groupByColumns.forEach(groupByColumn => {
-    //     if (groupByColumns.lastIndexOf(columnName) + 1 < Number(groupByColumn)) {
-    //       newGroupBy.push(Number(groupByColumn - 1));
-    //     } else if (
-    //       groupByColumns.lastIndexOf(columnName) + 1 !== groupByColumn &&
-    //       groupByColumn !== columnName
-    //     ) {
-    //       newGroupBy.push(groupByColumn);
-    //     }
-    //   });
-    // }
 
     return new SqlQuery({
       columns: new Columns({ columns: newColumns, parens: [], spacing: columnSpacing }),

--- a/src/playground.spec.ts
+++ b/src/playground.spec.ts
@@ -17,7 +17,7 @@ import { FUNCTIONS } from './test-utils';
 
 const parser = sqlParserFactory(FUNCTIONS);
 
-describe('Playground 1', () => {
+describe.skip('Playground 1', () => {
   it('remove first column in group by', () => {
     const tree = parser(`SELECT
   "page", "count", "user",

--- a/src/playground.spec.ts
+++ b/src/playground.spec.ts
@@ -17,10 +17,23 @@ import { FUNCTIONS } from './test-utils';
 
 const parser = sqlParserFactory(FUNCTIONS);
 
-describe.skip('Playground 1', () => {
-  it('basic', () => {
-    expect(parser(`TRIM( TRAILING 'M' FROM 'MADAM')`).toString()).toMatchInlineSnapshot(
-      `"TRIM( TRAILING 'M' undefined 'MADAM')"`,
-    );
+describe('Playground 1', () => {
+  it('remove first column in group by', () => {
+    const tree = parser(`SELECT
+  "page", "count", "user",
+  COUNT(*) AS "Count"
+FROM "wikipedia"
+GROUP BY 1,2,3
+ORDER BY "Count" DESC`)
+      .removeGroupBy('page')
+      .toString();
+
+    expect(tree).toMatchInlineSnapshot(`
+      "SELECT
+        \\"count\\", \\"user\\", COUNT(*) AS \\"Count\\"
+      FROM \\"wikipedia\\"
+      GROUP BY 1,2
+      ORDER BY \\"Count\\" DESC"
+    `);
   });
 });


### PR DESCRIPTION
This PR adds functionality for druid-query-toolkit so that a group-by can be removed for a certain column, similar to the removeFilter method.


Note: This will be followed by a PR for web-console to reflect the frontend changes, after this is approved.