### PR TITLE
Fix addColumnToGroupBy and addFunctionToGroupBy

### DIFF
--- a/src/sql/sql-function/sql-function.ts
+++ b/src/sql/sql-function/sql-function.ts
@@ -45,11 +45,13 @@ export class SqlFunction extends SqlBase {
     argumentArray: SqlBase[],
     separators?: Separator[],
     filter?: SqlBase,
+    decorator?: string,
   ) {
     const innerSpacing = {
       postName: '',
       preRightParen: '',
       postLeftParen: '',
+      postDecorator: decorator ? ' ' : '',
       preFilter: filter ? ' ' : '',
       postFilterKeyword: filter ? ' ' : '',
       postFilterLeftParen: filter ? ' ' : '',
@@ -58,6 +60,7 @@ export class SqlFunction extends SqlBase {
     };
     return new SqlFunction({
       type: SqlFunction.type,
+      decorator: decorator,
       functionName: functionName,
       arguments: argumentArray,
       separators: Separator.fillBetween(

--- a/src/sql/sql-query/operations.spec.ts
+++ b/src/sql/sql-query/operations.spec.ts
@@ -530,9 +530,32 @@ describe('addAggregateColumn', () => {
         .toString(),
     ).toMatchInlineSnapshot(`"select column1, min(column2) AS \\"alias\\" from table"`);
   });
+
+  it('function with decorator', () => {
+    const sql = 'select column1 from table';
+
+    expect(
+      parser(sql)
+        .addAggregateColumn([SqlRef.fromName('column2')], 'min', 'alias', undefined, 'DISTINCT')
+        .toString(),
+    ).toMatchInlineSnapshot(`"select column1, min(DISTINCT column2) AS \\"alias\\" from table"`);
+  });
 });
 
 describe('addToGroupBy', () => {
+  it('add simple column to group by', () => {
+    const sql = 'select Count(*) from table';
+
+    expect(
+      parser(sql)
+        .addColumnToGroupBy('column')
+        .toString(),
+    ).toMatchInlineSnapshot(`
+      "select \\"column\\", Count(*) from table
+      GROUP BY 1"
+    `);
+  });
+
   it('no existing column', () => {
     const sql = 'select column1 from table';
 

--- a/src/sql/sql-query/operations.spec.ts
+++ b/src/sql/sql-query/operations.spec.ts
@@ -564,8 +564,8 @@ describe('addToGroupBy', () => {
         .addFunctionToGroupBy([SqlRef.fromName('column1')], 'min', 'MinColumn')
         .toString(),
     ).toMatchInlineSnapshot(`
-      "select column1, min(column1) AS \\"MinColumn\\" from table
-      GROUP BY 2"
+      "select min(column1) AS \\"MinColumn\\", column1 from table
+      GROUP BY 1"
     `);
   });
 
@@ -720,8 +720,8 @@ describe('addToGroupBy', () => {
         .addFunctionToGroupBy([SqlRef.fromName('column2')], 'max', 'MaxColumn')
         .toString(),
     ).toMatchInlineSnapshot(`
-      "select column1, min(column1) AS aliasName, max(column2) AS \\"MaxColumn\\" from table 
-            GROUP BY 2, 3"
+      "select max(column2) AS \\"MaxColumn\\", column1, min(column1) AS aliasName from table 
+            GROUP BY 1, 3"
     `);
   });
 });

--- a/src/sql/sql-query/operations.spec.ts
+++ b/src/sql/sql-query/operations.spec.ts
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import { sqlParserFactory, SqlRef } from '../..';
+import { SqlAliasRef, SqlFunction, sqlParserFactory, SqlRef } from '../..';
 import { FUNCTIONS } from '../../test-utils';
 
 const parser = sqlParserFactory(FUNCTIONS);
@@ -548,7 +548,7 @@ describe('addToGroupBy', () => {
 
     expect(
       parser(sql)
-        .addColumnToGroupBy('column')
+        .addToGroupBy(SqlRef.fromNameWithDoubleQuotes('column'))
         .toString(),
     ).toMatchInlineSnapshot(`
       "select \\"column\\", Count(*) from table
@@ -561,7 +561,12 @@ describe('addToGroupBy', () => {
 
     expect(
       parser(sql)
-        .addFunctionToGroupBy([SqlRef.fromName('column1')], 'min', 'MinColumn')
+        .addToGroupBy(
+          SqlAliasRef.sqlAliasFactory(
+            SqlFunction.sqlFunctionFactory('min', [SqlRef.fromName('column1')]),
+            'MinColumn',
+          ),
+        )
         .toString(),
     ).toMatchInlineSnapshot(`
       "select min(column1) AS \\"MinColumn\\", column1 from table
@@ -717,7 +722,12 @@ describe('addToGroupBy', () => {
     `);
     expect(
       parser(sql)
-        .addFunctionToGroupBy([SqlRef.fromName('column2')], 'max', 'MaxColumn')
+        .addToGroupBy(
+          SqlAliasRef.sqlAliasFactory(
+            SqlFunction.sqlFunctionFactory('max', [SqlRef.fromName('column2')]),
+            'MaxColumn',
+          ),
+        )
         .toString(),
     ).toMatchInlineSnapshot(`
       "select max(column2) AS \\"MaxColumn\\", column1, min(column1) AS aliasName from table 

--- a/src/sql/sql-query/sql-query.ts
+++ b/src/sql/sql-query/sql-query.ts
@@ -711,10 +711,16 @@ export class SqlQuery extends SqlBase {
     return new SqlQuery(value);
   }
 
-  addFunctionToGroupBy(columns: SqlBase[], functionName: string, alias: string, filter?: SqlBase) {
+  addFunctionToGroupBy(
+    columns: SqlBase[],
+    functionName: string,
+    alias: string,
+    filter?: SqlBase,
+    decorator?: string,
+  ) {
     // adds a function to the group by clause with alias then adds the column to the group by clause using the index
     let value = new SqlQuery(this.valueOf());
-    value = value.addAggregateColumn(columns, functionName, alias, filter);
+    value = value.addAggregateColumn(columns, functionName, alias, filter, decorator);
     return value.addLastColumnToGroupBy();
   }
 
@@ -723,7 +729,7 @@ export class SqlQuery extends SqlBase {
     // column is added to the select clause then the index is added to group by clause
     let value = new SqlQuery(this.valueOf());
     value = value.addColumn(SqlRef.fromNameWithDoubleQuotes(column));
-    return value.addLastColumnToGroupBy();
+    return value.addFirstColumnToGroupBy();
   }
 
   addLastColumnToGroupBy() {
@@ -747,23 +753,60 @@ export class SqlQuery extends SqlBase {
     return new SqlQuery(value);
   }
 
+  addFirstColumnToGroupBy() {
+    // Adds the last column in the select clause to the group by clause via its index
+    const value = this.valueOf();
+
+    value.groupByExpression = [SqlLiteral.fromInput(1)].concat(
+      (value.groupByExpression || []).map(column => {
+        if (column instanceof SqlLiteral && typeof column.value === 'number') {
+          column.value += 1;
+          column.stringValue = `${column.value}`;
+        }
+        return column;
+      }),
+    );
+    value.groupByKeyword = value.groupByKeyword || 'GROUP BY';
+    value.groupByExpressionSeparators = this.groupByExpression
+      ? Separator.fillBetween(
+          value.groupByExpressionSeparators || [],
+          value.groupByExpression.length,
+          Separator.rightSeparator(','),
+        )
+      : undefined;
+    value.innerSpacing.postGroupByKeyword = value.innerSpacing.postGroupByKeyword || ' ';
+    value.innerSpacing.preGroupByKeyword = value.innerSpacing.preGroupByKeyword || `\n`;
+
+    return new SqlQuery(value);
+  }
+
   addColumn(column: SqlBase) {
     const value = this.valueOf();
     if (!value.selectValues) return new SqlQuery(value);
 
-    value.selectValues = value.selectValues.concat([column]);
+    value.selectValues = [column].concat(value.selectValues);
     value.selectSeparators = (value.selectSeparators || []).concat(Separator.rightSeparator(','));
     return new SqlQuery(value);
   }
 
-  addAggregateColumn(columns: SqlBase[], functionName: string, alias: string, filter?: SqlBase) {
+  addAggregateColumn(
+    columns: SqlBase[],
+    functionName: string,
+    alias: string,
+    filter?: SqlBase,
+    decorator?: string,
+  ) {
     // Adds an aggregate column to the select
+    const value = this.valueOf();
+
     const selectValue = SqlAliasRef.sqlAliasFactory(
-      SqlFunction.sqlFunctionFactory(functionName, columns, [], filter),
+      SqlFunction.sqlFunctionFactory(functionName, columns, [], filter, decorator),
       alias,
     );
 
-    return this.addColumn(selectValue);
+    value.selectValues = value.selectValues.concat([selectValue]);
+    value.selectSeparators = (value.selectSeparators || []).concat(Separator.rightSeparator(','));
+    return new SqlQuery(value);
   }
 
   getColumns() {

--- a/src/sql/sql-query/sql-query.ts
+++ b/src/sql/sql-query/sql-query.ts
@@ -719,9 +719,16 @@ export class SqlQuery extends SqlBase {
     decorator?: string,
   ) {
     // adds a function to the group by clause with alias then adds the column to the group by clause using the index
-    let value = new SqlQuery(this.valueOf());
-    value = value.addAggregateColumn(columns, functionName, alias, filter, decorator);
-    return value.addLastColumnToGroupBy();
+    const value = this.valueOf();
+
+    const selectValue = SqlAliasRef.sqlAliasFactory(
+      SqlFunction.sqlFunctionFactory(functionName, columns, [], filter, decorator),
+      alias,
+    );
+
+    value.selectValues = ([selectValue] as SqlBase[]).concat(value.selectValues || []);
+    value.selectSeparators = (value.selectSeparators || []).concat(Separator.rightSeparator(','));
+    return new SqlQuery(value).addFirstColumnToGroupBy();
   }
 
   addColumnToGroupBy(column: string) {

--- a/src/sql/sql-query/sql-query.ts
+++ b/src/sql/sql-query/sql-query.ts
@@ -711,31 +711,11 @@ export class SqlQuery extends SqlBase {
     return new SqlQuery(value);
   }
 
-  addFunctionToGroupBy(
-    columns: SqlBase[],
-    functionName: string,
-    alias: string,
-    filter?: SqlBase,
-    decorator?: string,
-  ) {
-    // adds a function to the group by clause with alias then adds the column to the group by clause using the index
-    const value = this.valueOf();
-
-    const selectValue = SqlAliasRef.sqlAliasFactory(
-      SqlFunction.sqlFunctionFactory(functionName, columns, [], filter, decorator),
-      alias,
-    );
-
-    value.selectValues = ([selectValue] as SqlBase[]).concat(value.selectValues || []);
-    value.selectSeparators = (value.selectSeparators || []).concat(Separator.rightSeparator(','));
-    return new SqlQuery(value).addFirstColumnToGroupBy();
-  }
-
-  addColumnToGroupBy(column: string) {
+  addToGroupBy(column: SqlBase) {
     // Adds a column with no alias to the group by clause
     // column is added to the select clause then the index is added to group by clause
     let value = new SqlQuery(this.valueOf());
-    value = value.addColumn(SqlRef.fromNameWithDoubleQuotes(column));
+    value = value.addColumn(column);
     return value.addFirstColumnToGroupBy();
   }
 


### PR DESCRIPTION
addColumnToGroup by replaces addFunctionToGroupBy and addColumnToGroupBy. It adds an SqlBase value to the front of the list and add a new index of 1 to the group by list and updates all other indexes by 1