### PR TITLE
support is not null and is null

### DIFF
--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -112,6 +112,7 @@ describe('Parser', () => {
       expect(parser(sql)).toMatchInlineSnapshot(`
         SqlLiteral {
           "innerSpacing": Object {},
+          "quotes": "'",
           "stringValue": "12345",
           "type": "literal",
           "value": 12345,
@@ -125,6 +126,7 @@ describe('Parser', () => {
       expect(parser(sql)).toMatchInlineSnapshot(`
         SqlLiteral {
           "innerSpacing": Object {},
+          "quotes": "'",
           "stringValue": "hello",
           "type": "literal",
           "value": "hello",

--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -112,7 +112,7 @@ describe('Parser', () => {
       expect(parser(sql)).toMatchInlineSnapshot(`
         SqlLiteral {
           "innerSpacing": Object {},
-          "quotes": "'",
+          "quotes": "",
           "stringValue": "12345",
           "type": "literal",
           "value": 12345,

--- a/src/parser/druidsql.pegjs
+++ b/src/parser/druidsql.pegjs
@@ -320,7 +320,7 @@ NotExpression = keyword:NotToken postKeyword:_ argument:(NotExpression/OrExpress
   }
   /ComparisonExpression
 
-ComparisonExpression = head:AdditionExpression tail:((__ ComparisonOperator __ (ComparisonExpression/AdditionExpression))/(_ BetweenToken _ (AndExpression/ComparisonExpression)))*
+ComparisonExpression = head:AdditionExpression tail:((__ ComparisonOperator __ (ComparisonExpression/AdditionExpression))/(_ BetweenToken _ (AndExpression/ComparisonExpression))/(_ (IsNotToken/IsToken) _ (NullToken)))*
   {
     if (!tail.length) return head
     return new sql.SqlMulti ({
@@ -738,4 +738,7 @@ IntervalToken = $('INTERVAL'i !IdentifierPart)
 TimestampToken = $('TIMESTAMP'i !IdentifierPart)
 OnToken = $('ON'i !IdentifierPart)
 JoinToken = $('JOIN'i !IdentifierPart)
+IsToken = $('IS'i !IdentifierPart)
+IsNotToken = $('IS'i _ 'NOT'i !IdentifierPart)
+NullToken = $('NULL'i !IdentifierPart)
 

--- a/src/parser/druidsql.pegjs
+++ b/src/parser/druidsql.pegjs
@@ -320,7 +320,7 @@ NotExpression = keyword:NotToken postKeyword:_ argument:(NotExpression/OrExpress
   }
   /ComparisonExpression
 
-ComparisonExpression = head:AdditionExpression tail:((__ ComparisonOperator __ (ComparisonExpression/AdditionExpression))/(_ BetweenToken _ (AndExpression/ComparisonExpression))/(_ (IsNotToken/IsToken) _ (NullToken)))*
+ComparisonExpression = head:AdditionExpression tail:((__ ComparisonOperator __ (ComparisonExpression/AdditionExpression))/(_ BetweenToken _ (AndExpression/ComparisonExpression))/(_ (IsNotToken/IsToken) _ (NullLiteral)))*
   {
     if (!tail.length) return head
     return new sql.SqlMulti ({
@@ -568,17 +568,28 @@ SqlInParens = OpenParen leftSpacing:_? ex:Sql rightSpacing:_? CloseParen
   return ex.addParens(leftSpacing, rightSpacing);
 }
 
-SqlLiteral = lit:(Number / SingleQuotedString)
+SqlLiteral = lit:(Number / SingleQuotedString )
 {
   return new sql.SqlLiteral(lit);
 }
+/ BooleanLiteral
 / SqlInParens
+
+NullLiteral = value: "NULL"i {
+    return new sql.SqlLiteral({value: value, stringValue: value, quotes:''});
+}
+
+BooleanLiteral = value: ("TRUE"i/"FALSE"i) {
+  return new sql.SqlLiteral({value: value, stringValue: value, quotes:''});
+}
+/NullLiteral
 
 Number = n:$([0-9]+)
 {
  return {
       value: parseInt(n, 10),
-      stringValue: n
+      stringValue: n,
+      quotes: ''
     };
 }
 
@@ -586,7 +597,8 @@ SingleQuotedString = ['] name:$([^']*) [']
 {
   return {
     value: name,
-    stringValue: name
+    stringValue: name,
+    quotes: "'"
   };
 }
 
@@ -740,5 +752,3 @@ OnToken = $('ON'i !IdentifierPart)
 JoinToken = $('JOIN'i !IdentifierPart)
 IsToken = $('IS'i !IdentifierPart)
 IsNotToken = $('IS'i _ 'NOT'i !IdentifierPart)
-NullToken = $('NULL'i !IdentifierPart)
-

--- a/src/parser/druidsql.pegjs
+++ b/src/parser/druidsql.pegjs
@@ -573,6 +573,7 @@ SqlLiteral = lit:(Number / SingleQuotedString )
   return new sql.SqlLiteral(lit);
 }
 / BooleanLiteral
+/ NullLiteral
 / SqlInParens
 
 NullLiteral = value: "NULL"i {
@@ -582,7 +583,6 @@ NullLiteral = value: "NULL"i {
 BooleanLiteral = value: ("TRUE"i/"FALSE"i) {
   return new sql.SqlLiteral({value: value, stringValue: value, quotes:''});
 }
-/NullLiteral
 
 Number = n:$([0-9]+)
 {

--- a/src/sql/sql-case-searched/sql-case-searched.spec.ts
+++ b/src/sql/sql-case-searched/sql-case-searched.spec.ts
@@ -465,6 +465,7 @@ describe('Case expression', () => {
         "caseKeyword": "CASE",
         "elseExpression": SqlLiteral {
           "innerSpacing": Object {},
+          "quotes": "'",
           "stringValue": "2",
           "type": "literal",
           "value": 2,
@@ -487,6 +488,7 @@ describe('Case expression', () => {
             "postWhenSpace": " ",
             "thenExpression": SqlLiteral {
               "innerSpacing": Object {},
+              "quotes": "'",
               "stringValue": "4",
               "type": "literal",
               "value": 4,
@@ -494,6 +496,7 @@ describe('Case expression', () => {
             "thenKeyword": "THEN",
             "whenExpression": SqlLiteral {
               "innerSpacing": Object {},
+              "quotes": "'",
               "stringValue": "RUNNING",
               "type": "literal",
               "value": "RUNNING",

--- a/src/sql/sql-case-searched/sql-case-searched.spec.ts
+++ b/src/sql/sql-case-searched/sql-case-searched.spec.ts
@@ -465,7 +465,7 @@ describe('Case expression', () => {
         "caseKeyword": "CASE",
         "elseExpression": SqlLiteral {
           "innerSpacing": Object {},
-          "quotes": "'",
+          "quotes": "",
           "stringValue": "2",
           "type": "literal",
           "value": 2,
@@ -488,7 +488,7 @@ describe('Case expression', () => {
             "postWhenSpace": " ",
             "thenExpression": SqlLiteral {
               "innerSpacing": Object {},
-              "quotes": "'",
+              "quotes": "",
               "stringValue": "4",
               "type": "literal",
               "value": 4,

--- a/src/sql/sql-function/sql-function.spec.ts
+++ b/src/sql/sql-function/sql-function.spec.ts
@@ -117,12 +117,14 @@ describe('Functions', () => {
                 "arguments": Array [
                   SqlLiteral {
                     "innerSpacing": Object {},
+                    "quotes": "'",
                     "stringValue": "1",
                     "type": "literal",
                     "value": 1,
                   },
                   SqlLiteral {
                     "innerSpacing": Object {},
+                    "quotes": "'",
                     "stringValue": "2",
                     "type": "literal",
                     "value": 2,
@@ -143,12 +145,14 @@ describe('Functions', () => {
                 "arguments": Array [
                   SqlLiteral {
                     "innerSpacing": Object {},
+                    "quotes": "'",
                     "stringValue": "3",
                     "type": "literal",
                     "value": 3,
                   },
                   SqlLiteral {
                     "innerSpacing": Object {},
+                    "quotes": "'",
                     "stringValue": "2",
                     "type": "literal",
                     "value": 2,
@@ -349,6 +353,7 @@ describe('Functions', () => {
                   },
                   SqlLiteral {
                     "innerSpacing": Object {},
+                    "quotes": "'",
                     "stringValue": "4",
                     "type": "literal",
                     "value": 4,
@@ -440,6 +445,7 @@ describe('Functions', () => {
             },
             SqlLiteral {
               "innerSpacing": Object {},
+              "quotes": "'",
               "stringValue": "1",
               "type": "literal",
               "value": 1,

--- a/src/sql/sql-function/sql-function.spec.ts
+++ b/src/sql/sql-function/sql-function.spec.ts
@@ -117,14 +117,14 @@ describe('Functions', () => {
                 "arguments": Array [
                   SqlLiteral {
                     "innerSpacing": Object {},
-                    "quotes": "'",
+                    "quotes": "",
                     "stringValue": "1",
                     "type": "literal",
                     "value": 1,
                   },
                   SqlLiteral {
                     "innerSpacing": Object {},
-                    "quotes": "'",
+                    "quotes": "",
                     "stringValue": "2",
                     "type": "literal",
                     "value": 2,
@@ -145,14 +145,14 @@ describe('Functions', () => {
                 "arguments": Array [
                   SqlLiteral {
                     "innerSpacing": Object {},
-                    "quotes": "'",
+                    "quotes": "",
                     "stringValue": "3",
                     "type": "literal",
                     "value": 3,
                   },
                   SqlLiteral {
                     "innerSpacing": Object {},
-                    "quotes": "'",
+                    "quotes": "",
                     "stringValue": "2",
                     "type": "literal",
                     "value": 2,
@@ -353,7 +353,7 @@ describe('Functions', () => {
                   },
                   SqlLiteral {
                     "innerSpacing": Object {},
-                    "quotes": "'",
+                    "quotes": "",
                     "stringValue": "4",
                     "type": "literal",
                     "value": 4,
@@ -445,7 +445,7 @@ describe('Functions', () => {
             },
             SqlLiteral {
               "innerSpacing": Object {},
-              "quotes": "'",
+              "quotes": "",
               "stringValue": "1",
               "type": "literal",
               "value": 1,

--- a/src/sql/sql-interval/sql-interval.spec.ts
+++ b/src/sql/sql-interval/sql-interval.spec.ts
@@ -31,6 +31,7 @@ describe('Intervals', () => {
         "intervalKeyword": "INTERVAL",
         "intervalValue": SqlLiteral {
           "innerSpacing": Object {},
+          "quotes": "'",
           "stringValue": "1",
           "type": "literal",
           "value": "1",
@@ -54,6 +55,7 @@ describe('Intervals', () => {
         "intervalKeyword": "INTERVAL",
         "intervalValue": SqlLiteral {
           "innerSpacing": Object {},
+          "quotes": "'",
           "stringValue": "1-2",
           "type": "literal",
           "value": "1-2",
@@ -77,6 +79,7 @@ describe('Intervals', () => {
         "intervalKeyword": "INTERVAL",
         "intervalValue": SqlLiteral {
           "innerSpacing": Object {},
+          "quotes": "'",
           "stringValue": "1-2",
           "type": "literal",
           "value": "1-2",

--- a/src/sql/sql-literal/sql-literal.spec.ts
+++ b/src/sql/sql-literal/sql-literal.spec.ts
@@ -84,4 +84,17 @@ describe('literal', () => {
       }
     `);
   });
+  it('empty literal', () => {
+    const sql = `''`;
+
+    expect(parser(sql).toString()).toMatchInlineSnapshot(`"''"`);
+    expect(parser(sql)).toMatchInlineSnapshot(`
+      SqlLiteral {
+        "innerSpacing": Object {},
+        "stringValue": "",
+        "type": "literal",
+        "value": "",
+      }
+    `);
+  });
 });

--- a/src/sql/sql-literal/sql-literal.spec.ts
+++ b/src/sql/sql-literal/sql-literal.spec.ts
@@ -25,6 +25,7 @@ describe('literal', () => {
     expect(parser(sql)).toMatchInlineSnapshot(`
       SqlLiteral {
         "innerSpacing": Object {},
+        "quotes": "'",
         "stringValue": "word",
         "type": "literal",
         "value": "word",
@@ -39,6 +40,7 @@ describe('literal', () => {
     expect(parser(sql)).toMatchInlineSnapshot(`
       SqlLiteral {
         "innerSpacing": Object {},
+        "quotes": "'",
         "stringValue": "1",
         "type": "literal",
         "value": 1,
@@ -59,6 +61,7 @@ describe('literal', () => {
             "rightSpacing": "",
           },
         ],
+        "quotes": "'",
         "stringValue": "1",
         "type": "literal",
         "value": 1,
@@ -78,6 +81,7 @@ describe('literal', () => {
             "rightSpacing": "",
           },
         ],
+        "quotes": "'",
         "stringValue": "word",
         "type": "literal",
         "value": "word",
@@ -91,6 +95,7 @@ describe('literal', () => {
     expect(parser(sql)).toMatchInlineSnapshot(`
       SqlLiteral {
         "innerSpacing": Object {},
+        "quotes": "'",
         "stringValue": "",
         "type": "literal",
         "value": "",

--- a/src/sql/sql-literal/sql-literal.spec.ts
+++ b/src/sql/sql-literal/sql-literal.spec.ts
@@ -40,7 +40,7 @@ describe('literal', () => {
     expect(parser(sql)).toMatchInlineSnapshot(`
       SqlLiteral {
         "innerSpacing": Object {},
-        "quotes": "'",
+        "quotes": "",
         "stringValue": "1",
         "type": "literal",
         "value": 1,
@@ -61,7 +61,7 @@ describe('literal', () => {
             "rightSpacing": "",
           },
         ],
-        "quotes": "'",
+        "quotes": "",
         "stringValue": "1",
         "type": "literal",
         "value": 1,

--- a/src/sql/sql-literal/sql-literal.ts
+++ b/src/sql/sql-literal/sql-literal.ts
@@ -53,7 +53,7 @@ export class SqlLiteral extends SqlBase {
   }
 
   public toRawString(): string {
-    if (!this.stringValue && !(this.stringValue === '')) {
+    if (!this.stringValue && this.stringValue !== '') {
       throw new Error('Could not make raw string');
     }
 

--- a/src/sql/sql-literal/sql-literal.ts
+++ b/src/sql/sql-literal/sql-literal.ts
@@ -53,7 +53,7 @@ export class SqlLiteral extends SqlBase {
   }
 
   public toRawString(): string {
-    if (!this.stringValue) {
+    if (!this.stringValue && !(this.stringValue === '')) {
       throw new Error('Could not make raw string');
     }
 

--- a/src/sql/sql-literal/sql-literal.ts
+++ b/src/sql/sql-literal/sql-literal.ts
@@ -17,6 +17,7 @@ import { SqlBase, SqlBaseValue } from '../sql-base';
 export interface SqlLiteralValue extends SqlBaseValue {
   value?: string | number;
   stringValue?: string;
+  quotes?: string;
 }
 
 export class SqlLiteral extends SqlBase {
@@ -29,6 +30,7 @@ export class SqlLiteral extends SqlBase {
     return new SqlLiteral({
       value: value,
       stringValue: typeof value === 'number' ? String(value) : value,
+      quotes: `'`,
     } as SqlLiteralValue);
   }
 
@@ -38,17 +40,20 @@ export class SqlLiteral extends SqlBase {
 
   public value?: string | number;
   public stringValue?: string;
+  public quotes?: string;
 
   constructor(options: SqlLiteralValue) {
     super(options, SqlLiteral.type);
     this.value = options.value;
     this.stringValue = options.stringValue;
+    this.quotes = options.quotes;
   }
 
   public valueOf() {
     const value: SqlLiteralValue = super.valueOf();
     value.value = this.value;
     value.stringValue = this.stringValue;
+    value.quotes = this.quotes;
     return value;
   }
 
@@ -57,8 +62,8 @@ export class SqlLiteral extends SqlBase {
       throw new Error('Could not make raw string');
     }
 
-    if (typeof this.value === 'string') {
-      return SqlLiteral.wrapInQuotes(this.value, `'`);
+    if (typeof this.value === 'string' && this.quotes) {
+      return SqlLiteral.wrapInQuotes(this.value, this.quotes);
     }
     return this.stringValue;
   }

--- a/src/sql/sql-multi/sql-multi.spec.ts
+++ b/src/sql/sql-multi/sql-multi.spec.ts
@@ -67,12 +67,14 @@ describe('OR expression', () => {
         "arguments": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "'",
             "stringValue": "A",
             "type": "literal",
             "value": "A",
           },
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "'",
             "stringValue": "B",
             "type": "literal",
             "value": "B",
@@ -141,12 +143,14 @@ describe('OR expression', () => {
         "arguments": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "1",
             "type": "literal",
             "value": 1,
           },
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "2",
             "type": "literal",
             "value": 2,
@@ -174,12 +178,14 @@ describe('OR expression', () => {
         "arguments": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "1",
             "type": "literal",
             "value": 1,
           },
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "2",
             "type": "literal",
             "value": 2,
@@ -213,12 +219,14 @@ describe('OR expression', () => {
         "arguments": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "1",
             "type": "literal",
             "value": 1,
           },
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "2",
             "type": "literal",
             "value": 2,
@@ -246,12 +254,14 @@ describe('OR expression', () => {
         "arguments": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "1",
             "type": "literal",
             "value": 1,
           },
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "2",
             "type": "literal",
             "value": 2,
@@ -329,12 +339,14 @@ describe('AND expression', () => {
         "arguments": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "'",
             "stringValue": "A",
             "type": "literal",
             "value": "A",
           },
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "'",
             "stringValue": "B",
             "type": "literal",
             "value": "B",
@@ -405,12 +417,14 @@ describe('AND expression', () => {
         "arguments": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "1",
             "type": "literal",
             "value": 1,
           },
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "2",
             "type": "literal",
             "value": 2,
@@ -439,12 +453,14 @@ describe('AND expression', () => {
         "arguments": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "1",
             "type": "literal",
             "value": 1,
           },
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "2",
             "type": "literal",
             "value": 2,
@@ -523,12 +539,14 @@ describe('Comparison expression', () => {
         "arguments": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "'",
             "stringValue": "A",
             "type": "literal",
             "value": "A",
           },
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "'",
             "stringValue": "B",
             "type": "literal",
             "value": "B",
@@ -599,12 +617,14 @@ describe('Comparison expression', () => {
         "arguments": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "1",
             "type": "literal",
             "value": 1,
           },
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "2",
             "type": "literal",
             "value": 2,
@@ -633,12 +653,14 @@ describe('Comparison expression', () => {
         "arguments": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "1",
             "type": "literal",
             "value": 1,
           },
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "2",
             "type": "literal",
             "value": 2,
@@ -969,12 +991,14 @@ describe('Math expression', () => {
         "arguments": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "1",
             "type": "literal",
             "value": 1,
           },
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "2",
             "type": "literal",
             "value": 2,
@@ -1003,12 +1027,14 @@ describe('Math expression', () => {
         "arguments": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "1",
             "type": "literal",
             "value": 1,
           },
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "2",
             "type": "literal",
             "value": 2,
@@ -1037,12 +1063,14 @@ describe('Math expression', () => {
         "arguments": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "1",
             "type": "literal",
             "value": 1,
           },
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "2",
             "type": "literal",
             "value": 2,
@@ -1071,12 +1099,14 @@ describe('Math expression', () => {
         "arguments": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "1",
             "type": "literal",
             "value": 1,
           },
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "2",
             "type": "literal",
             "value": 2,
@@ -1147,12 +1177,14 @@ describe('Math expression', () => {
         "arguments": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "'",
             "stringValue": "A",
             "type": "literal",
             "value": "A",
           },
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "'",
             "stringValue": "B",
             "type": "literal",
             "value": "B",
@@ -1223,12 +1255,14 @@ describe('Math expression', () => {
         "arguments": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "1",
             "type": "literal",
             "value": 1,
           },
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "2",
             "type": "literal",
             "value": 2,
@@ -1257,12 +1291,14 @@ describe('Math expression', () => {
         "arguments": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "1",
             "type": "literal",
             "value": 1,
           },
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "",
             "stringValue": "2",
             "type": "literal",
             "value": 2,
@@ -2340,6 +2376,7 @@ describe('getSqlRefs', () => {
               },
               SqlLiteral {
                 "innerSpacing": Object {},
+                "quotes": "'",
                 "stringValue": "San",
                 "type": "literal",
                 "value": "San",
@@ -2370,7 +2407,13 @@ describe('getSqlRefs', () => {
             "whereExpression": undefined,
             "whereKeyword": undefined,
           },
-          "NULL",
+          SqlLiteral {
+            "innerSpacing": Object {},
+            "quotes": "",
+            "stringValue": "NULL",
+            "type": "literal",
+            "value": "NULL",
+          },
         ],
         "expressionType": "Comparison",
         "innerSpacing": Object {},
@@ -2386,7 +2429,7 @@ describe('getSqlRefs', () => {
     `);
   });
 
-  it('IS Not function', () => {
+  it('IS NOT function', () => {
     const sql = `X IS NOT NULL`;
 
     expect(parser(sql).toString()).toMatchInlineSnapshot(`"X IS NOT NULL"`);
@@ -2404,7 +2447,13 @@ describe('getSqlRefs', () => {
             "tableQuotes": undefined,
             "type": "ref",
           },
-          "NULL",
+          SqlLiteral {
+            "innerSpacing": Object {},
+            "quotes": "",
+            "stringValue": "NULL",
+            "type": "literal",
+            "value": "NULL",
+          },
         ],
         "expressionType": "Comparison",
         "innerSpacing": Object {},
@@ -2439,7 +2488,13 @@ describe('getSqlRefs', () => {
                 "tableQuotes": undefined,
                 "type": "ref",
               },
-              "NULL",
+              SqlLiteral {
+                "innerSpacing": Object {},
+                "quotes": "",
+                "stringValue": "NULL",
+                "type": "literal",
+                "value": "NULL",
+              },
             ],
             "expressionType": "Comparison",
             "innerSpacing": Object {},
@@ -2466,6 +2521,7 @@ describe('getSqlRefs', () => {
               },
               SqlLiteral {
                 "innerSpacing": Object {},
+                "quotes": "'",
                 "stringValue": "",
                 "type": "literal",
                 "value": "",

--- a/src/sql/sql-multi/sql-multi.spec.ts
+++ b/src/sql/sql-multi/sql-multi.spec.ts
@@ -2316,4 +2316,289 @@ describe('getSqlRefs', () => {
       }
     `);
   });
+  it('IS function', () => {
+    const sql = `REGEXP_EXTRACT("cityName", 'San') IS NULL`;
+
+    expect(parser(sql).toString()).toMatchInlineSnapshot(
+      `"REGEXP_EXTRACT(\\"cityName\\", 'San') IS NULL"`,
+    );
+
+    expect(parser(sql)).toMatchInlineSnapshot(`
+      SqlMulti {
+        "arguments": Array [
+          SqlFunction {
+            "arguments": Array [
+              SqlRef {
+                "column": "cityName",
+                "innerSpacing": Object {},
+                "namespace": undefined,
+                "namespaceQuotes": undefined,
+                "quotes": "\\"",
+                "table": undefined,
+                "tableQuotes": undefined,
+                "type": "ref",
+              },
+              SqlLiteral {
+                "innerSpacing": Object {},
+                "stringValue": "San",
+                "type": "literal",
+                "value": "San",
+              },
+            ],
+            "decorator": undefined,
+            "filterKeyword": undefined,
+            "functionName": "REGEXP_EXTRACT",
+            "innerSpacing": Object {
+              "postDecorator": "",
+              "postFilterKeyword": "",
+              "postFilterLeftParen": "",
+              "postLeftParen": "",
+              "postName": "",
+              "postWhereKeyword": "",
+              "preFilter": "",
+              "preFilterRightParen": "",
+              "preRightParen": "",
+            },
+            "separators": Array [
+              Separator {
+                "left": "",
+                "right": " ",
+                "separator": ",",
+              },
+            ],
+            "type": "function",
+            "whereExpression": undefined,
+            "whereKeyword": undefined,
+          },
+          "NULL",
+        ],
+        "expressionType": "Comparison",
+        "innerSpacing": Object {},
+        "separators": Array [
+          Separator {
+            "left": " ",
+            "right": " ",
+            "separator": "IS",
+          },
+        ],
+        "type": "multi",
+      }
+    `);
+  });
+  it('IS Not function', () => {
+    const sql = `REGEXP_EXTRACT("cityName", 'San') IS NOT NULL`;
+
+    expect(parser(sql).toString()).toMatchInlineSnapshot(
+      `"REGEXP_EXTRACT(\\"cityName\\", 'San') IS NOT NULL"`,
+    );
+
+    expect(parser(sql)).toMatchInlineSnapshot(`
+      SqlMulti {
+        "arguments": Array [
+          SqlFunction {
+            "arguments": Array [
+              SqlRef {
+                "column": "cityName",
+                "innerSpacing": Object {},
+                "namespace": undefined,
+                "namespaceQuotes": undefined,
+                "quotes": "\\"",
+                "table": undefined,
+                "tableQuotes": undefined,
+                "type": "ref",
+              },
+              SqlLiteral {
+                "innerSpacing": Object {},
+                "stringValue": "San",
+                "type": "literal",
+                "value": "San",
+              },
+            ],
+            "decorator": undefined,
+            "filterKeyword": undefined,
+            "functionName": "REGEXP_EXTRACT",
+            "innerSpacing": Object {
+              "postDecorator": "",
+              "postFilterKeyword": "",
+              "postFilterLeftParen": "",
+              "postLeftParen": "",
+              "postName": "",
+              "postWhereKeyword": "",
+              "preFilter": "",
+              "preFilterRightParen": "",
+              "preRightParen": "",
+            },
+            "separators": Array [
+              Separator {
+                "left": "",
+                "right": " ",
+                "separator": ",",
+              },
+            ],
+            "type": "function",
+            "whereExpression": undefined,
+            "whereKeyword": undefined,
+          },
+          "NULL",
+        ],
+        "expressionType": "Comparison",
+        "innerSpacing": Object {},
+        "separators": Array [
+          Separator {
+            "left": " ",
+            "right": " ",
+            "separator": "IS NOT",
+          },
+        ],
+        "type": "multi",
+      }
+    `);
+  });
+  it('Nested IS Not function', () => {
+    const sql = `REGEXP_EXTRACT("cityName", 'San') IS NOT NULL AND REGEXP_EXTRACT("cityName", 'San') <> ''`;
+
+    expect(parser(sql).toString()).toMatchInlineSnapshot(
+      `"REGEXP_EXTRACT(\\"cityName\\", 'San') IS NOT NULL AND REGEXP_EXTRACT(\\"cityName\\", 'San') <> ''"`,
+    );
+
+    expect(parser(sql)).toMatchInlineSnapshot(`
+      SqlMulti {
+        "arguments": Array [
+          SqlMulti {
+            "arguments": Array [
+              SqlFunction {
+                "arguments": Array [
+                  SqlRef {
+                    "column": "cityName",
+                    "innerSpacing": Object {},
+                    "namespace": undefined,
+                    "namespaceQuotes": undefined,
+                    "quotes": "\\"",
+                    "table": undefined,
+                    "tableQuotes": undefined,
+                    "type": "ref",
+                  },
+                  SqlLiteral {
+                    "innerSpacing": Object {},
+                    "stringValue": "San",
+                    "type": "literal",
+                    "value": "San",
+                  },
+                ],
+                "decorator": undefined,
+                "filterKeyword": undefined,
+                "functionName": "REGEXP_EXTRACT",
+                "innerSpacing": Object {
+                  "postDecorator": "",
+                  "postFilterKeyword": "",
+                  "postFilterLeftParen": "",
+                  "postLeftParen": "",
+                  "postName": "",
+                  "postWhereKeyword": "",
+                  "preFilter": "",
+                  "preFilterRightParen": "",
+                  "preRightParen": "",
+                },
+                "separators": Array [
+                  Separator {
+                    "left": "",
+                    "right": " ",
+                    "separator": ",",
+                  },
+                ],
+                "type": "function",
+                "whereExpression": undefined,
+                "whereKeyword": undefined,
+              },
+              "NULL",
+            ],
+            "expressionType": "Comparison",
+            "innerSpacing": Object {},
+            "separators": Array [
+              Separator {
+                "left": " ",
+                "right": " ",
+                "separator": "IS NOT",
+              },
+            ],
+            "type": "multi",
+          },
+          SqlMulti {
+            "arguments": Array [
+              SqlFunction {
+                "arguments": Array [
+                  SqlRef {
+                    "column": "cityName",
+                    "innerSpacing": Object {},
+                    "namespace": undefined,
+                    "namespaceQuotes": undefined,
+                    "quotes": "\\"",
+                    "table": undefined,
+                    "tableQuotes": undefined,
+                    "type": "ref",
+                  },
+                  SqlLiteral {
+                    "innerSpacing": Object {},
+                    "stringValue": "San",
+                    "type": "literal",
+                    "value": "San",
+                  },
+                ],
+                "decorator": undefined,
+                "filterKeyword": undefined,
+                "functionName": "REGEXP_EXTRACT",
+                "innerSpacing": Object {
+                  "postDecorator": "",
+                  "postFilterKeyword": "",
+                  "postFilterLeftParen": "",
+                  "postLeftParen": "",
+                  "postName": "",
+                  "postWhereKeyword": "",
+                  "preFilter": "",
+                  "preFilterRightParen": "",
+                  "preRightParen": "",
+                },
+                "separators": Array [
+                  Separator {
+                    "left": "",
+                    "right": " ",
+                    "separator": ",",
+                  },
+                ],
+                "type": "function",
+                "whereExpression": undefined,
+                "whereKeyword": undefined,
+              },
+              SqlLiteral {
+                "innerSpacing": Object {},
+                "stringValue": "",
+                "type": "literal",
+                "value": "",
+              },
+            ],
+            "expressionType": "Comparison",
+            "innerSpacing": Object {},
+            "separators": Array [
+              Separator {
+                "left": " ",
+                "right": " ",
+                "separator": "<>",
+              },
+            ],
+            "type": "multi",
+          },
+        ],
+        "expressionType": "AND",
+        "innerSpacing": Object {},
+        "separators": Array [
+          Separator {
+            "left": " ",
+            "right": " ",
+            "separator": "AND",
+          },
+        ],
+        "type": "multi",
+      }
+    `);
+  });
 });

--- a/src/sql/sql-multi/sql-multi.spec.ts
+++ b/src/sql/sql-multi/sql-multi.spec.ts
@@ -2353,59 +2353,22 @@ describe('getSqlRefs', () => {
     `);
   });
   it('IS function', () => {
-    const sql = `REGEXP_EXTRACT("cityName", 'San') IS NULL`;
+    const sql = `X IS NULL`;
 
-    expect(parser(sql).toString()).toMatchInlineSnapshot(
-      `"REGEXP_EXTRACT(\\"cityName\\", 'San') IS NULL"`,
-    );
+    expect(parser(sql).toString()).toMatchInlineSnapshot(`"X IS NULL"`);
 
     expect(parser(sql)).toMatchInlineSnapshot(`
       SqlMulti {
         "arguments": Array [
-          SqlFunction {
-            "arguments": Array [
-              SqlRef {
-                "column": "cityName",
-                "innerSpacing": Object {},
-                "namespace": undefined,
-                "namespaceQuotes": undefined,
-                "quotes": "\\"",
-                "table": undefined,
-                "tableQuotes": undefined,
-                "type": "ref",
-              },
-              SqlLiteral {
-                "innerSpacing": Object {},
-                "quotes": "'",
-                "stringValue": "San",
-                "type": "literal",
-                "value": "San",
-              },
-            ],
-            "decorator": undefined,
-            "filterKeyword": undefined,
-            "functionName": "REGEXP_EXTRACT",
-            "innerSpacing": Object {
-              "postDecorator": "",
-              "postFilterKeyword": "",
-              "postFilterLeftParen": "",
-              "postLeftParen": "",
-              "postName": "",
-              "postWhereKeyword": "",
-              "preFilter": "",
-              "preFilterRightParen": "",
-              "preRightParen": "",
-            },
-            "separators": Array [
-              Separator {
-                "left": "",
-                "right": " ",
-                "separator": ",",
-              },
-            ],
-            "type": "function",
-            "whereExpression": undefined,
-            "whereKeyword": undefined,
+          SqlRef {
+            "column": "X",
+            "innerSpacing": Object {},
+            "namespace": undefined,
+            "namespaceQuotes": undefined,
+            "quotes": "",
+            "table": undefined,
+            "tableQuotes": undefined,
+            "type": "ref",
           },
           SqlLiteral {
             "innerSpacing": Object {},

--- a/src/sql/sql-multi/sql-multi.spec.ts
+++ b/src/sql/sql-multi/sql-multi.spec.ts
@@ -2385,59 +2385,24 @@ describe('getSqlRefs', () => {
       }
     `);
   });
-  it('IS Not function', () => {
-    const sql = `REGEXP_EXTRACT("cityName", 'San') IS NOT NULL`;
 
-    expect(parser(sql).toString()).toMatchInlineSnapshot(
-      `"REGEXP_EXTRACT(\\"cityName\\", 'San') IS NOT NULL"`,
-    );
+  it('IS Not function', () => {
+    const sql = `X IS NOT NULL`;
+
+    expect(parser(sql).toString()).toMatchInlineSnapshot(`"X IS NOT NULL"`);
 
     expect(parser(sql)).toMatchInlineSnapshot(`
       SqlMulti {
         "arguments": Array [
-          SqlFunction {
-            "arguments": Array [
-              SqlRef {
-                "column": "cityName",
-                "innerSpacing": Object {},
-                "namespace": undefined,
-                "namespaceQuotes": undefined,
-                "quotes": "\\"",
-                "table": undefined,
-                "tableQuotes": undefined,
-                "type": "ref",
-              },
-              SqlLiteral {
-                "innerSpacing": Object {},
-                "stringValue": "San",
-                "type": "literal",
-                "value": "San",
-              },
-            ],
-            "decorator": undefined,
-            "filterKeyword": undefined,
-            "functionName": "REGEXP_EXTRACT",
-            "innerSpacing": Object {
-              "postDecorator": "",
-              "postFilterKeyword": "",
-              "postFilterLeftParen": "",
-              "postLeftParen": "",
-              "postName": "",
-              "postWhereKeyword": "",
-              "preFilter": "",
-              "preFilterRightParen": "",
-              "preRightParen": "",
-            },
-            "separators": Array [
-              Separator {
-                "left": "",
-                "right": " ",
-                "separator": ",",
-              },
-            ],
-            "type": "function",
-            "whereExpression": undefined,
-            "whereKeyword": undefined,
+          SqlRef {
+            "column": "X",
+            "innerSpacing": Object {},
+            "namespace": undefined,
+            "namespaceQuotes": undefined,
+            "quotes": "",
+            "table": undefined,
+            "tableQuotes": undefined,
+            "type": "ref",
           },
           "NULL",
         ],
@@ -2455,60 +2420,24 @@ describe('getSqlRefs', () => {
     `);
   });
   it('Nested IS Not function', () => {
-    const sql = `REGEXP_EXTRACT("cityName", 'San') IS NOT NULL AND REGEXP_EXTRACT("cityName", 'San') <> ''`;
+    const sql = `X IS NOT NULL AND X <> ''`;
 
-    expect(parser(sql).toString()).toMatchInlineSnapshot(
-      `"REGEXP_EXTRACT(\\"cityName\\", 'San') IS NOT NULL AND REGEXP_EXTRACT(\\"cityName\\", 'San') <> ''"`,
-    );
+    expect(parser(sql).toString()).toMatchInlineSnapshot(`"X IS NOT NULL AND X <> ''"`);
 
     expect(parser(sql)).toMatchInlineSnapshot(`
       SqlMulti {
         "arguments": Array [
           SqlMulti {
             "arguments": Array [
-              SqlFunction {
-                "arguments": Array [
-                  SqlRef {
-                    "column": "cityName",
-                    "innerSpacing": Object {},
-                    "namespace": undefined,
-                    "namespaceQuotes": undefined,
-                    "quotes": "\\"",
-                    "table": undefined,
-                    "tableQuotes": undefined,
-                    "type": "ref",
-                  },
-                  SqlLiteral {
-                    "innerSpacing": Object {},
-                    "stringValue": "San",
-                    "type": "literal",
-                    "value": "San",
-                  },
-                ],
-                "decorator": undefined,
-                "filterKeyword": undefined,
-                "functionName": "REGEXP_EXTRACT",
-                "innerSpacing": Object {
-                  "postDecorator": "",
-                  "postFilterKeyword": "",
-                  "postFilterLeftParen": "",
-                  "postLeftParen": "",
-                  "postName": "",
-                  "postWhereKeyword": "",
-                  "preFilter": "",
-                  "preFilterRightParen": "",
-                  "preRightParen": "",
-                },
-                "separators": Array [
-                  Separator {
-                    "left": "",
-                    "right": " ",
-                    "separator": ",",
-                  },
-                ],
-                "type": "function",
-                "whereExpression": undefined,
-                "whereKeyword": undefined,
+              SqlRef {
+                "column": "X",
+                "innerSpacing": Object {},
+                "namespace": undefined,
+                "namespaceQuotes": undefined,
+                "quotes": "",
+                "table": undefined,
+                "tableQuotes": undefined,
+                "type": "ref",
               },
               "NULL",
             ],
@@ -2525,49 +2454,15 @@ describe('getSqlRefs', () => {
           },
           SqlMulti {
             "arguments": Array [
-              SqlFunction {
-                "arguments": Array [
-                  SqlRef {
-                    "column": "cityName",
-                    "innerSpacing": Object {},
-                    "namespace": undefined,
-                    "namespaceQuotes": undefined,
-                    "quotes": "\\"",
-                    "table": undefined,
-                    "tableQuotes": undefined,
-                    "type": "ref",
-                  },
-                  SqlLiteral {
-                    "innerSpacing": Object {},
-                    "stringValue": "San",
-                    "type": "literal",
-                    "value": "San",
-                  },
-                ],
-                "decorator": undefined,
-                "filterKeyword": undefined,
-                "functionName": "REGEXP_EXTRACT",
-                "innerSpacing": Object {
-                  "postDecorator": "",
-                  "postFilterKeyword": "",
-                  "postFilterLeftParen": "",
-                  "postLeftParen": "",
-                  "postName": "",
-                  "postWhereKeyword": "",
-                  "preFilter": "",
-                  "preFilterRightParen": "",
-                  "preRightParen": "",
-                },
-                "separators": Array [
-                  Separator {
-                    "left": "",
-                    "right": " ",
-                    "separator": ",",
-                  },
-                ],
-                "type": "function",
-                "whereExpression": undefined,
-                "whereKeyword": undefined,
+              SqlRef {
+                "column": "X",
+                "innerSpacing": Object {},
+                "namespace": undefined,
+                "namespaceQuotes": undefined,
+                "quotes": "",
+                "table": undefined,
+                "tableQuotes": undefined,
+                "type": "ref",
               },
               SqlLiteral {
                 "innerSpacing": Object {},

--- a/src/sql/sql-query/default-queries.spec.ts
+++ b/src/sql/sql-query/default-queries.spec.ts
@@ -482,4 +482,22 @@ describe('Special function tests', () => {
         ORDER BY \\"Count\\" DESC"
     `);
   });
+
+  it('IS NOT NULL Where Clause', () => {
+    expect(
+      parser(`SELECT
+SUM("count") AS "TotalEdits",
+SUM("added") AS "TotalAdded"
+FROM "wikipedia"
+WHERE REGEXP_EXTRACT("cityName", 'San') IS NOT NULL AND REGEXP_EXTRACT("cityName", 'San') <> ''
+GROUP BY ''`).toString(),
+    ).toMatchInlineSnapshot(`
+      "SELECT
+      SUM(\\"count\\") AS \\"TotalEdits\\",
+      SUM(\\"added\\") AS \\"TotalAdded\\"
+      FROM \\"wikipedia\\"
+      WHERE REGEXP_EXTRACT(\\"cityName\\", 'San') IS NOT NULL AND REGEXP_EXTRACT(\\"cityName\\", 'San') <> ''
+      GROUP BY ''"
+    `);
+  });
 });

--- a/src/sql/sql-query/operations.spec.ts
+++ b/src/sql/sql-query/operations.spec.ts
@@ -585,6 +585,7 @@ describe('addToGroupBy', () => {
         "groupByExpression": Array [
           SqlLiteral {
             "innerSpacing": Object {},
+            "quotes": "'",
             "stringValue": "2",
             "type": "literal",
             "value": 2,

--- a/src/sql/sql-query/operations.spec.ts
+++ b/src/sql/sql-query/operations.spec.ts
@@ -585,7 +585,7 @@ describe('addToGroupBy', () => {
         "groupByExpression": Array [
           SqlLiteral {
             "innerSpacing": Object {},
-            "quotes": "'",
+            "quotes": "",
             "stringValue": "2",
             "type": "literal",
             "value": 2,

--- a/src/sql/sql-query/sql-query.spec.ts
+++ b/src/sql/sql-query/sql-query.spec.ts
@@ -566,7 +566,7 @@ FROM sys.segments`;
                   "postWhenSpace": " ",
                   "thenExpression": SqlLiteral {
                     "innerSpacing": Object {},
-                    "quotes": "'",
+                    "quotes": "",
                     "stringValue": "0",
                     "type": "literal",
                     "value": 0,
@@ -608,7 +608,7 @@ FROM sys.segments`;
                       },
                       SqlLiteral {
                         "innerSpacing": Object {},
-                        "quotes": "'",
+                        "quotes": "",
                         "stringValue": "0",
                         "type": "literal",
                         "value": 0,
@@ -698,7 +698,7 @@ FROM sys.segments`;
                   "postWhenSpace": " ",
                   "thenExpression": SqlLiteral {
                     "innerSpacing": Object {},
-                    "quotes": "'",
+                    "quotes": "",
                     "stringValue": "0",
                     "type": "literal",
                     "value": 0,
@@ -740,7 +740,7 @@ FROM sys.segments`;
                       },
                       SqlLiteral {
                         "innerSpacing": Object {},
-                        "quotes": "'",
+                        "quotes": "",
                         "stringValue": "0",
                         "type": "literal",
                         "value": 0,
@@ -1468,7 +1468,7 @@ describe('expressions with where clause', () => {
             },
             SqlLiteral {
               "innerSpacing": Object {},
-              "quotes": "'",
+              "quotes": "",
               "stringValue": "1",
               "type": "literal",
               "value": 1,
@@ -1594,7 +1594,7 @@ describe('expressions with where clause', () => {
             },
             SqlLiteral {
               "innerSpacing": Object {},
-              "quotes": "'",
+              "quotes": "",
               "stringValue": "0",
               "type": "literal",
               "value": 0,
@@ -1724,7 +1724,7 @@ describe('expressions with where clause', () => {
                     },
                     SqlLiteral {
                       "innerSpacing": Object {},
-                      "quotes": "'",
+                      "quotes": "",
                       "stringValue": "0",
                       "type": "literal",
                       "value": 0,
@@ -1755,7 +1755,7 @@ describe('expressions with where clause', () => {
                     },
                     SqlLiteral {
                       "innerSpacing": Object {},
-                      "quotes": "'",
+                      "quotes": "",
                       "stringValue": "100",
                       "type": "literal",
                       "value": 100,
@@ -2203,7 +2203,7 @@ describe('expressions with having clause', () => {
             },
             SqlLiteral {
               "innerSpacing": Object {},
-              "quotes": "'",
+              "quotes": "",
               "stringValue": "1",
               "type": "literal",
               "value": 1,
@@ -2329,7 +2329,7 @@ describe('expressions with having clause', () => {
             },
             SqlLiteral {
               "innerSpacing": Object {},
-              "quotes": "'",
+              "quotes": "",
               "stringValue": "0",
               "type": "literal",
               "value": 0,
@@ -2459,7 +2459,7 @@ describe('expressions with having clause', () => {
                     },
                     SqlLiteral {
                       "innerSpacing": Object {},
-                      "quotes": "'",
+                      "quotes": "",
                       "stringValue": "0",
                       "type": "literal",
                       "value": 0,
@@ -2490,7 +2490,7 @@ describe('expressions with having clause', () => {
                     },
                     SqlLiteral {
                       "innerSpacing": Object {},
-                      "quotes": "'",
+                      "quotes": "",
                       "stringValue": "100",
                       "type": "literal",
                       "value": 100,
@@ -2698,7 +2698,7 @@ describe('expressions with order by clause', () => {
             "direction": "",
             "expression": SqlLiteral {
               "innerSpacing": Object {},
-              "quotes": "'",
+              "quotes": "",
               "stringValue": "1",
               "type": "literal",
               "value": 1,
@@ -2919,7 +2919,7 @@ describe('expressions with order by clause', () => {
             "direction": "ASC",
             "expression": SqlLiteral {
               "innerSpacing": Object {},
-              "quotes": "'",
+              "quotes": "",
               "stringValue": "1",
               "type": "literal",
               "value": 1,
@@ -3163,7 +3163,7 @@ describe('expressions with order by clause', () => {
             "direction": "ASC",
             "expression": SqlLiteral {
               "innerSpacing": Object {},
-              "quotes": "'",
+              "quotes": "",
               "stringValue": "1",
               "type": "literal",
               "value": 1,
@@ -3292,7 +3292,7 @@ describe('expressions with order by clause', () => {
             "direction": "ASC",
             "expression": SqlLiteral {
               "innerSpacing": Object {},
-              "quotes": "'",
+              "quotes": "",
               "stringValue": "1",
               "type": "literal",
               "value": 1,
@@ -3422,7 +3422,7 @@ describe('expressions with limit clause', () => {
         "limitKeyword": "limit",
         "limitValue": SqlLiteral {
           "innerSpacing": Object {},
-          "quotes": "'",
+          "quotes": "",
           "stringValue": "1",
           "type": "literal",
           "value": 1,

--- a/src/sql/sql-query/sql-query.spec.ts
+++ b/src/sql/sql-query/sql-query.spec.ts
@@ -566,6 +566,7 @@ FROM sys.segments`;
                   "postWhenSpace": " ",
                   "thenExpression": SqlLiteral {
                     "innerSpacing": Object {},
+                    "quotes": "'",
                     "stringValue": "0",
                     "type": "literal",
                     "value": 0,
@@ -607,6 +608,7 @@ FROM sys.segments`;
                       },
                       SqlLiteral {
                         "innerSpacing": Object {},
+                        "quotes": "'",
                         "stringValue": "0",
                         "type": "literal",
                         "value": 0,
@@ -696,6 +698,7 @@ FROM sys.segments`;
                   "postWhenSpace": " ",
                   "thenExpression": SqlLiteral {
                     "innerSpacing": Object {},
+                    "quotes": "'",
                     "stringValue": "0",
                     "type": "literal",
                     "value": 0,
@@ -737,6 +740,7 @@ FROM sys.segments`;
                       },
                       SqlLiteral {
                         "innerSpacing": Object {},
+                        "quotes": "'",
                         "stringValue": "0",
                         "type": "literal",
                         "value": 0,
@@ -1464,6 +1468,7 @@ describe('expressions with where clause', () => {
             },
             SqlLiteral {
               "innerSpacing": Object {},
+              "quotes": "'",
               "stringValue": "1",
               "type": "literal",
               "value": 1,
@@ -1589,6 +1594,7 @@ describe('expressions with where clause', () => {
             },
             SqlLiteral {
               "innerSpacing": Object {},
+              "quotes": "'",
               "stringValue": "0",
               "type": "literal",
               "value": 0,
@@ -1718,6 +1724,7 @@ describe('expressions with where clause', () => {
                     },
                     SqlLiteral {
                       "innerSpacing": Object {},
+                      "quotes": "'",
                       "stringValue": "0",
                       "type": "literal",
                       "value": 0,
@@ -1748,6 +1755,7 @@ describe('expressions with where clause', () => {
                     },
                     SqlLiteral {
                       "innerSpacing": Object {},
+                      "quotes": "'",
                       "stringValue": "100",
                       "type": "literal",
                       "value": 100,
@@ -1790,6 +1798,7 @@ describe('expressions with where clause', () => {
                 },
                 SqlLiteral {
                   "innerSpacing": Object {},
+                  "quotes": "'",
                   "stringValue": "value",
                   "type": "literal",
                   "value": "value",
@@ -2194,6 +2203,7 @@ describe('expressions with having clause', () => {
             },
             SqlLiteral {
               "innerSpacing": Object {},
+              "quotes": "'",
               "stringValue": "1",
               "type": "literal",
               "value": 1,
@@ -2319,6 +2329,7 @@ describe('expressions with having clause', () => {
             },
             SqlLiteral {
               "innerSpacing": Object {},
+              "quotes": "'",
               "stringValue": "0",
               "type": "literal",
               "value": 0,
@@ -2448,6 +2459,7 @@ describe('expressions with having clause', () => {
                     },
                     SqlLiteral {
                       "innerSpacing": Object {},
+                      "quotes": "'",
                       "stringValue": "0",
                       "type": "literal",
                       "value": 0,
@@ -2478,6 +2490,7 @@ describe('expressions with having clause', () => {
                     },
                     SqlLiteral {
                       "innerSpacing": Object {},
+                      "quotes": "'",
                       "stringValue": "100",
                       "type": "literal",
                       "value": 100,
@@ -2520,6 +2533,7 @@ describe('expressions with having clause', () => {
                 },
                 SqlLiteral {
                   "innerSpacing": Object {},
+                  "quotes": "'",
                   "stringValue": "value",
                   "type": "literal",
                   "value": "value",
@@ -2684,6 +2698,7 @@ describe('expressions with order by clause', () => {
             "direction": "",
             "expression": SqlLiteral {
               "innerSpacing": Object {},
+              "quotes": "'",
               "stringValue": "1",
               "type": "literal",
               "value": 1,
@@ -2904,6 +2919,7 @@ describe('expressions with order by clause', () => {
             "direction": "ASC",
             "expression": SqlLiteral {
               "innerSpacing": Object {},
+              "quotes": "'",
               "stringValue": "1",
               "type": "literal",
               "value": 1,
@@ -3147,6 +3163,7 @@ describe('expressions with order by clause', () => {
             "direction": "ASC",
             "expression": SqlLiteral {
               "innerSpacing": Object {},
+              "quotes": "'",
               "stringValue": "1",
               "type": "literal",
               "value": 1,
@@ -3275,6 +3292,7 @@ describe('expressions with order by clause', () => {
             "direction": "ASC",
             "expression": SqlLiteral {
               "innerSpacing": Object {},
+              "quotes": "'",
               "stringValue": "1",
               "type": "literal",
               "value": 1,
@@ -3404,6 +3422,7 @@ describe('expressions with limit clause', () => {
         "limitKeyword": "limit",
         "limitValue": SqlLiteral {
           "innerSpacing": Object {},
+          "quotes": "'",
           "stringValue": "1",
           "type": "literal",
           "value": 1,

--- a/src/sql/sql-timeStamp/sql-timestamp.spec.ts
+++ b/src/sql/sql-timeStamp/sql-timestamp.spec.ts
@@ -30,6 +30,7 @@ describe('Timestamp', () => {
         "timestampKeyword": "TIMESTAMP",
         "timestampValue": SqlLiteral {
           "innerSpacing": Object {},
+          "quotes": "'",
           "stringValue": "2020-02-25 00:00:00",
           "type": "literal",
           "value": "2020-02-25 00:00:00",

--- a/src/sql/sql-unary/sql-unary.spec.ts
+++ b/src/sql/sql-unary/sql-unary.spec.ts
@@ -238,6 +238,7 @@ describe('Not expression', () => {
                 },
                 SqlLiteral {
                   "innerSpacing": Object {},
+                  "quotes": "'",
                   "stringValue": "D",
                   "type": "literal",
                   "value": "D",


### PR DESCRIPTION
- Adds the ability to parse IS NOT NULL and IS NULL as a comparison expression
- Adds the ability to parse an empty string literal: ''