### PR TITLE
Fix sql query parsing limit clause incorrectly when converting a sql query to a string

### DIFF
--- a/src/introspect/introspect.spec.ts
+++ b/src/introspect/introspect.spec.ts
@@ -135,11 +135,15 @@ describe('Introspect', () => {
         Introspect.getQueryColumnSampleQuery(
           SqlQuery.parse(sane`
             SELECT added + 1, * FROM "wikipedia"
+            Union All
+            SELECT * FROM "wiki"
           `),
         ),
       ),
     ).toEqual(sane`
       SELECT added + 1, * FROM "wikipedia"
+      Union All
+      SELECT * FROM "wiki"
       LIMIT 1
     `);
   });

--- a/src/sql/sql-query/sql-query.ts
+++ b/src/sql/sql-query/sql-query.ts
@@ -254,6 +254,15 @@ export class SqlQuery extends SqlExpression {
       rawParts.push(this.getSpace('preWhereClause', '\n'), whereClause.toString());
     }
 
+    if (unionQuery) {
+      rawParts.push(
+        this.getSpace('preUnion', '\n'),
+        this.getKeyword('union', SqlQuery.DEFAULT_UNION_KEYWORD),
+        this.getSpace('postUnion'),
+        unionQuery.toString(),
+      );
+    }
+
     if (groupByClause) {
       rawParts.push(this.getSpace('preGroupByClause', '\n'), groupByClause.toString());
     }
@@ -280,15 +289,6 @@ export class SqlQuery extends SqlExpression {
 
     if (clusteredByClause) {
       rawParts.push(this.getSpace('preClusteredByClause', '\n'), clusteredByClause.toString());
-    }
-
-    if (unionQuery) {
-      rawParts.push(
-        this.getSpace('preUnion', '\n'),
-        this.getKeyword('union', SqlQuery.DEFAULT_UNION_KEYWORD),
-        this.getSpace('postUnion'),
-        unionQuery.toString(),
-      );
     }
 
     return rawParts.join('');


### PR DESCRIPTION
If we have a SQL query string like:
sql_query_string = `SELECT * FROM <Table_2>  
UNION ALL 
SELECT * FROM <TABLE_2>
` 

and we create a `sqlQueryObj` by calling `SqlQuery.parse(sql_query_string)`

the output generated from calling `String(sqlQueryObj)` violates the SQL query syntax if both a `LIMIT` clause and a `UNION ALL` clause are set.  Sample output is like this:

`SELECT * FROM <Table_2>  
LIMIT 1 
UNION ALL 
SELECT * FROM <TABLE_2>
`

But it should be:
`SELECT * FROM <Table_2>  
UNION ALL 
SELECT * FROM <TABLE_2>
LIMIT 1 
`
