### PR TITLE
Make Cancel compatible with axios 0.26

### DIFF
--- a/src/query-runner/cancel-token.ts
+++ b/src/query-runner/cancel-token.ts
@@ -13,7 +13,7 @@
  */
 
 export interface Cancel {
-  message: string;
+  message: string | undefined;
 }
 
 export interface CancelToken {


### PR DESCRIPTION
Axios defines `message` as `string | undefined` now: https://github.com/axios/axios/blob/master/index.d.ts#L181

Without this change, applications that use newer versions of axios that pass cancel tokens to the toolkit will get compiler errors.