### PR TITLE
add sql tag function

### DIFF
--- a/src/filter-pattern/pattern-contains.ts
+++ b/src/filter-pattern/pattern-contains.ts
@@ -12,8 +12,9 @@
  * limitations under the License.
  */
 
+import { C, F, L } from '../shortcuts';
 import type { SqlExpression } from '../sql';
-import { C, F, L, SqlColumn, SqlFunction } from '../sql';
+import { SqlColumn, SqlFunction } from '../sql';
 
 import type { FilterPatternDefinition } from './common';
 import { castAsVarchar, extractOuterNot, unwrapCastAsVarchar } from './common';

--- a/src/filter-pattern/pattern-mv-contains.ts
+++ b/src/filter-pattern/pattern-mv-contains.ts
@@ -12,8 +12,9 @@
  * limitations under the License.
  */
 
+import { C, F } from '../shortcuts';
 import type { LiteralValue, SqlExpression } from '../sql';
-import { C, F, SqlColumn, SqlFunction, SqlLiteral } from '../sql';
+import { SqlColumn, SqlFunction, SqlLiteral } from '../sql';
 import { filterMap } from '../utils';
 
 import type { FilterPatternDefinition } from './common';

--- a/src/filter-pattern/pattern-number-range.ts
+++ b/src/filter-pattern/pattern-number-range.ts
@@ -12,7 +12,8 @@
  * limitations under the License.
  */
 
-import { C, L, SqlColumn, SqlComparison, SqlExpression, SqlLiteral, SqlMulti } from '../sql';
+import { C, L } from '../shortcuts';
+import { SqlColumn, SqlComparison, SqlExpression, SqlLiteral, SqlMulti } from '../sql';
 
 import type { FilterPatternDefinition } from './common';
 import { extractOuterNot } from './common';

--- a/src/filter-pattern/pattern-regexp.ts
+++ b/src/filter-pattern/pattern-regexp.ts
@@ -12,8 +12,9 @@
  * limitations under the License.
  */
 
+import { C, F, L } from '../shortcuts';
 import type { SqlExpression } from '../sql';
-import { C, F, L, SqlColumn, SqlFunction, SqlLiteral } from '../sql';
+import { SqlColumn, SqlFunction, SqlLiteral } from '../sql';
 
 import type { FilterPatternDefinition } from './common';
 import { castAsVarchar, extractOuterNot, unwrapCastAsVarchar } from './common';

--- a/src/filter-pattern/pattern-time-interval.ts
+++ b/src/filter-pattern/pattern-time-interval.ts
@@ -12,8 +12,9 @@
  * limitations under the License.
  */
 
+import { C, F, L } from '../shortcuts';
 import type { SqlExpression } from '../sql';
-import { C, F, L, SqlColumn, SqlFunction } from '../sql';
+import { SqlColumn, SqlFunction } from '../sql';
 
 import type { FilterPatternDefinition } from './common';
 import { extractOuterNot } from './common';

--- a/src/filter-pattern/pattern-time-relative.ts
+++ b/src/filter-pattern/pattern-time-relative.ts
@@ -12,8 +12,9 @@
  * limitations under the License.
  */
 
+import { C, F } from '../shortcuts';
 import type { SqlExpression } from '../sql';
-import { C, F, RefName, SqlColumn, SqlComparison, SqlFunction, SqlMulti } from '../sql';
+import { RefName, SqlColumn, SqlComparison, SqlFunction, SqlMulti } from '../sql';
 
 import type { FilterPatternDefinition } from './common';
 import { extractOuterNot, oneOf } from './common';

--- a/src/filter-pattern/pattern-values.ts
+++ b/src/filter-pattern/pattern-values.ts
@@ -12,8 +12,9 @@
  * limitations under the License.
  */
 
+import { C } from '../shortcuts';
 import type { LiteralValue, SqlExpression } from '../sql';
-import { C, SqlColumn, SqlComparison, SqlLiteral, SqlPlaceholder, SqlRecord } from '../sql';
+import { SqlColumn, SqlComparison, SqlLiteral, SqlPlaceholder, SqlRecord } from '../sql';
 
 import type { FilterPatternDefinition } from './common';
 import { extractOuterNot, sqlRecordGetLiteralValues } from './common';

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@
 /* eslint-disable simple-import-sort/exports */
 export * from './utils';
 export * from './sql';
+export * from './shortcuts';
 export * from './introspect/introspect';
 export * from './query-result/column';
 export * from './query-result/query-result';

--- a/src/shortcuts/column.ts
+++ b/src/shortcuts/column.ts
@@ -12,12 +12,12 @@
  * limitations under the License.
  */
 
-import { SqlTable } from '../sql-table/sql-table';
+import { SqlColumn } from '../sql';
 
-export function T(name: string | SqlTable) {
-  return SqlTable.create(name);
+export function C(name: string | SqlColumn) {
+  return SqlColumn.create(name);
 }
 
-T.optionalQuotes = (name: string | SqlTable) => {
-  return SqlTable.optionalQuotes(name);
+C.optionalQuotes = (name: string | SqlColumn) => {
+  return SqlColumn.optionalQuotes(name);
 };

--- a/src/shortcuts/function.ts
+++ b/src/shortcuts/function.ts
@@ -12,9 +12,7 @@
  * limitations under the License.
  */
 
-import { SqlExpression } from '../sql-expression';
-import { SqlFunction } from '../sql-function/sql-function';
-import { LiteralValue, SqlLiteral } from '../sql-literal/sql-literal';
+import { LiteralValue, SqlExpression, SqlFunction, SqlLiteral } from '../sql';
 
 export const F = function (name: string, ...args: (SqlExpression | LiteralValue | undefined)[]) {
   // Trim undefined values of the end

--- a/src/shortcuts/index.ts
+++ b/src/shortcuts/index.ts
@@ -12,12 +12,9 @@
  * limitations under the License.
  */
 
-import { SqlNamespace } from '../sql-namespace/sql-namespace';
-
-export function N(name: string | SqlNamespace) {
-  return SqlNamespace.create(name);
-}
-
-N.optionalQuotes = (name: string | SqlNamespace) => {
-  return SqlNamespace.optionalQuotes(name);
-};
+export * from './column';
+export * from './function';
+export * from './literal';
+export * from './namespace';
+export * from './table';
+export * from './template';

--- a/src/shortcuts/literal.ts
+++ b/src/shortcuts/literal.ts
@@ -12,8 +12,12 @@
  * limitations under the License.
  */
 
-export * from './column';
-export * from './function';
-export * from './literal';
-export * from './namespace';
-export * from './table';
+import { LiteralValue, SqlLiteral } from '../sql';
+
+export function L(value: LiteralValue | SqlLiteral) {
+  return SqlLiteral.create(value);
+}
+
+L.NULL = SqlLiteral.NULL;
+L.FALSE = SqlLiteral.FALSE;
+L.TRUE = SqlLiteral.TRUE;

--- a/src/shortcuts/namespace.ts
+++ b/src/shortcuts/namespace.ts
@@ -12,12 +12,12 @@
  * limitations under the License.
  */
 
-import { LiteralValue, SqlLiteral } from '../sql-literal/sql-literal';
+import { SqlNamespace } from '../sql';
 
-export function L(value: LiteralValue | SqlLiteral) {
-  return SqlLiteral.create(value);
+export function N(name: string | SqlNamespace) {
+  return SqlNamespace.create(name);
 }
 
-L.NULL = SqlLiteral.NULL;
-L.FALSE = SqlLiteral.FALSE;
-L.TRUE = SqlLiteral.TRUE;
+N.optionalQuotes = (name: string | SqlNamespace) => {
+  return SqlNamespace.optionalQuotes(name);
+};

--- a/src/shortcuts/table.ts
+++ b/src/shortcuts/table.ts
@@ -12,12 +12,12 @@
  * limitations under the License.
  */
 
-import { SqlColumn } from '../sql-column/sql-column';
+import { SqlTable } from '../sql';
 
-export function C(name: string | SqlColumn) {
-  return SqlColumn.create(name);
+export function T(name: string | SqlTable) {
+  return SqlTable.create(name);
 }
 
-C.optionalQuotes = (name: string | SqlColumn) => {
-  return SqlColumn.optionalQuotes(name);
+T.optionalQuotes = (name: string | SqlTable) => {
+  return SqlTable.optionalQuotes(name);
 };

--- a/src/shortcuts/template.spec.ts
+++ b/src/shortcuts/template.spec.ts
@@ -12,7 +12,8 @@
  * limitations under the License.
  */
 
-import { C, sql } from '.';
+import { C } from '.';
+import { sql } from './template';
 
 describe('sql', () => {
   it('works in basic case', () => {

--- a/src/shortcuts/template.spec.ts
+++ b/src/shortcuts/template.spec.ts
@@ -42,28 +42,28 @@ describe('sql', () => {
   it('throws on uneven double quote wrapping (start)', () => {
     const c = C('blah');
     expect(() => sql`SELECT * FROM tbl WHERE "${c} = 5`).toThrow(
-      'the expression `"blah"` is not evenly wrapped in double quotes',
+      'Expression `"blah"` is not evenly wrapped in double quotes',
     );
   });
 
   it('throws on uneven double quote wrapping (end)', () => {
     const c = C('blah');
     expect(() => sql`SELECT * FROM tbl WHERE ${c}" = 5`).toThrow(
-      'the expression `"blah"` is not evenly wrapped in double quotes',
+      'Expression `"blah"` is not evenly wrapped in double quotes',
     );
   });
 
   it('throws on uneven single quote wrapping (start)', () => {
     const v = 'blah';
     expect(() => sql`SELECT * FROM tbl WHERE col = '${v}`).toThrow(
-      'the literal `blah` is not evenly wrapped in single quotes',
+      'Literal `blah` is not evenly wrapped in single quotes',
     );
   });
 
   it('throws on uneven single quote wrapping (end)', () => {
     const v = 'blah';
     expect(() => sql`SELECT * FROM tbl WHERE col = ${v}'`).toThrow(
-      'the literal `blah` is not evenly wrapped in single quotes',
+      'Literal `blah` is not evenly wrapped in single quotes',
     );
   });
 });

--- a/src/shortcuts/template.spec.ts
+++ b/src/shortcuts/template.spec.ts
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { C, sql } from '.';
+
+describe('sql', () => {
+  it('works in basic case', () => {
+    expect(String(sql`SELECT * FROM tbl`)).toEqual(`SELECT * FROM tbl`);
+  });
+
+  it('works in complex case', () => {
+    const column = 'some_column';
+    const tbl = 'this is a "table" and I like it';
+    const v1 = 'foo';
+    const v2 = 'bar';
+    expect(
+      String(sql`SELECT * FROM "${tbl}" WHERE ${C(column)} = ${5} AND "x" IN (${v1}, '${v2}')`),
+    ).toEqual(
+      `SELECT * FROM "this is a ""table"" and I like it" WHERE "some_column" = 5 AND "x" IN ('foo', 'bar')`,
+    );
+  });
+
+  it('wrapping in single quotes forces a literal string', () => {
+    const c = C('blah');
+    expect(String(sql`SELECT * FROM tbl WHERE x = '${c}'`)).toEqual(
+      `SELECT * FROM tbl WHERE x = '"blah"'`,
+    );
+  });
+
+  it('throws on uneven double quote wrapping (start)', () => {
+    const c = C('blah');
+    expect(() => sql`SELECT * FROM tbl WHERE "${c} = 5`).toThrow(
+      'the expression `"blah"` is not evenly wrapped in double quotes',
+    );
+  });
+
+  it('throws on uneven double quote wrapping (end)', () => {
+    const c = C('blah');
+    expect(() => sql`SELECT * FROM tbl WHERE ${c}" = 5`).toThrow(
+      'the expression `"blah"` is not evenly wrapped in double quotes',
+    );
+  });
+
+  it('throws on uneven single quote wrapping (start)', () => {
+    const v = 'blah';
+    expect(() => sql`SELECT * FROM tbl WHERE col = '${v}`).toThrow(
+      'the literal `blah` is not evenly wrapped in single quotes',
+    );
+  });
+
+  it('throws on uneven single quote wrapping (end)', () => {
+    const v = 'blah';
+    expect(() => sql`SELECT * FROM tbl WHERE col = ${v}'`).toThrow(
+      'the literal `blah` is not evenly wrapped in single quotes',
+    );
+  });
+});

--- a/src/shortcuts/template.ts
+++ b/src/shortcuts/template.ts
@@ -28,29 +28,29 @@ export function sql(strings: TemplateStringsArray, ...xs: any[]): SqlExpression 
       case '"': {
         // Detect ..."${x}"...
         if (afterFirstChar !== '"') {
-          throw new Error(`the expression \`${x}\` is not evenly wrapped in double quotes`);
+          throw new Error(`Expression \`${x}\` is not evenly wrapped in double quotes`);
         }
         const str = RefName.create(String(x)).toString();
-        toAdd = str.slice(1, str.length - 1);
+        toAdd = str.slice(1, -1); // Remove double quotes as they are already accounted for
         break;
       }
 
       case "'": {
         // Detect ...'${x}'...
         if (afterFirstChar !== "'") {
-          throw new Error(`the literal \`${x}\` is not evenly wrapped in single quotes`);
+          throw new Error(`Literal \`${x}\` is not evenly wrapped in single quotes`);
         }
         const str = SqlLiteral.create(String(x)).toString();
-        toAdd = str.slice(1, str.length - 1);
+        toAdd = str.slice(1, -1); // Remove single quotes as they are already accounted for
         break;
       }
 
       default:
         if (afterFirstChar === '"') {
-          throw new Error(`the expression \`${x}\` is not evenly wrapped in double quotes`);
+          throw new Error(`Expression \`${x}\` is not evenly wrapped in double quotes`);
         }
         if (afterFirstChar === "'") {
-          throw new Error(`the literal \`${x}\` is not evenly wrapped in single quotes`);
+          throw new Error(`Literal \`${x}\` is not evenly wrapped in single quotes`);
         }
         toAdd = SqlExpression.wrap(x).toString();
         break;

--- a/src/shortcuts/template.ts
+++ b/src/shortcuts/template.ts
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RefName, SqlExpression, SqlLiteral } from '../sql';
+
+export function sql(strings: TemplateStringsArray, ...xs: any[]): SqlExpression {
+  const parts: string[] = strings.slice(0, 1);
+  const n = xs.length;
+  for (let i = 0; i < n; i++) {
+    const x = xs[i];
+    const before = strings[i]!;
+    const beforeLastChar = before[before.length - 1];
+    const after = strings[i + 1]!;
+    const afterFirstChar = after[0];
+    let toAdd: string;
+    switch (beforeLastChar) {
+      case '"': {
+        // Detect ..."${x}"...
+        if (afterFirstChar !== '"') {
+          throw new Error(`the expression \`${x}\` is not evenly wrapped in double quotes`);
+        }
+        const str = RefName.create(String(x)).toString();
+        toAdd = str.slice(1, str.length - 1);
+        break;
+      }
+
+      case "'": {
+        // Detect ...'${x}'...
+        if (afterFirstChar !== "'") {
+          throw new Error(`the literal \`${x}\` is not evenly wrapped in single quotes`);
+        }
+        const str = SqlLiteral.create(String(x)).toString();
+        toAdd = str.slice(1, str.length - 1);
+        break;
+      }
+
+      default:
+        if (afterFirstChar === '"') {
+          throw new Error(`the expression \`${x}\` is not evenly wrapped in double quotes`);
+        }
+        if (afterFirstChar === "'") {
+          throw new Error(`the literal \`${x}\` is not evenly wrapped in single quotes`);
+        }
+        toAdd = SqlExpression.wrap(x).toString();
+        break;
+    }
+    parts.push(toAdd, after);
+  }
+
+  return SqlExpression.parse(parts.join(''));
+}

--- a/src/sql/index.ts
+++ b/src/sql/index.ts
@@ -47,5 +47,3 @@ export * from './sql-values/sql-values';
 export * from './sql-function/sql-function';
 export * from './sql-query/sql-query';
 export * from './sql-with-query/sql-with-query';
-
-export * from './shortcuts';


### PR DESCRIPTION
See tests for details, helps users write not totally horrible sql via string templates.
Also moved `shortcuts` to live in `src` instead if `src/sql`