### PR TITLE
Add functions to support introspection from a limit 0 query 

### DIFF
--- a/src/introspect/introspect.spec.ts
+++ b/src/introspect/introspect.spec.ts
@@ -670,4 +670,135 @@ describe('Introspect', () => {
       ]);
     });
   });
+
+  describe('.decodeLimit0QueryColumnIntrospectionResult', () => {
+    it('works with all types', () => {
+      const queryResult = new QueryResult({
+        header: Column.fromColumnNames([
+          '__time',
+          'isRobot',
+          'country',
+          'comment',
+          'count',
+          'sum_delta',
+          'sum_deltaBucket',
+          'user',
+          'comment_length',
+          'someNumber',
+          'someNumber',
+          'someNumber',
+        ]),
+        rows: [
+          [
+            { type: 'LONG', sqlType: 'TIMESTAMP' },
+            { type: 'LONG', sqlType: 'BOOLEAN' },
+            { type: 'STRING', sqlType: 'VARCHAR' },
+            { type: 'STRING', sqlType: 'CHAR' },
+            { type: 'LONG', sqlType: 'LONG' },
+            { type: 'DOUBLE', sqlType: 'DECIMAL' },
+            { type: 'DOUBLE', sqlType: 'REAL' },
+            { type: 'DOUBLE', sqlType: 'DOUBLE' },
+            { type: 'FLOAT', sqlType: 'FLOAT' },
+            { type: 'LONG', sqlType: 'TINYINT' },
+            { type: 'LONG', sqlType: 'SMALLINT' },
+            { type: 'LONG', sqlType: 'BIGINT' },
+          ],
+        ],
+      });
+
+      expect(Introspect.decodeLimit0QueryColumnIntrospectionResult(queryResult)).toEqual([
+        {
+          name: '__time',
+          type: 'TIMESTAMP',
+        },
+        {
+          name: 'isRobot',
+          type: 'BOOLEAN',
+        },
+        {
+          name: 'country',
+          type: 'STRING',
+        },
+        {
+          name: 'comment',
+          type: 'STRING',
+        },
+        {
+          name: 'count',
+          type: 'LONG',
+        },
+        {
+          name: 'sum_delta',
+          type: 'DOUBLE',
+        },
+        {
+          name: 'sum_deltaBucket',
+          type: 'DOUBLE',
+        },
+        {
+          name: 'user',
+          type: 'DOUBLE',
+        },
+        {
+          name: 'comment_length',
+          type: 'FLOAT',
+        },
+        {
+          name: 'someNumber',
+          type: 'LONG',
+        },
+        {
+          name: 'someNumber',
+          type: 'LONG',
+        },
+        {
+          name: 'someNumber',
+          type: 'LONG',
+        },
+      ]);
+    });
+    it('works with some columns having complex data types', () => {
+      const sampleResult = new QueryResult({
+        header: Column.fromColumnNames([
+          'time',
+          'cityName',
+          'distinct_cityName',
+          'delta',
+          'deleted',
+        ]),
+        rows: [
+          [
+            { type: 'LONG', sqlType: 'TIMESTAMP' },
+            { type: 'STRING', sqlType: 'VARCHAR' },
+            { type: 'COMPLEX<HLLSketch>', sqlType: 'COMPLEX<HLLSketch>_' },
+            { type: 'LONG', sqlType: 'BIGINT' },
+            { type: 'LONG', sqlType: 'BOOLEAN' },
+          ],
+        ],
+      });
+
+      expect(Introspect.decodeLimit0QueryColumnIntrospectionResult(sampleResult)).toEqual([
+        {
+          name: 'time',
+          type: 'TIMESTAMP',
+        },
+        {
+          name: 'cityName',
+          type: 'STRING',
+        },
+        {
+          name: 'distinct_cityName',
+          type: 'COMPLEX<HLLSketch>',
+        },
+        {
+          name: 'delta',
+          type: 'LONG',
+        },
+        {
+          name: 'deleted',
+          type: 'BOOLEAN',
+        },
+      ]);
+    });
+  });
 });

--- a/src/introspect/introspect.ts
+++ b/src/introspect/introspect.ts
@@ -83,7 +83,6 @@ export class Introspect {
       payload.header = true;
       payload.typesHeader = true;
       payload.sqlTypesHeader = true;
-      payload.resultFormat = 'array';
     }
     return payload;
   }

--- a/src/introspect/introspect.ts
+++ b/src/introspect/introspect.ts
@@ -27,7 +27,6 @@ export interface ColumnInfo {
 
 interface Limit0QueryColumnIntrospectionQuery {
   query: string;
-  context: Record<string, any>;
   header?: true;
   typesHeader?: true;
   sqlTypesHeader?: true;
@@ -77,18 +76,13 @@ export class Introspect {
 
   static getLimit0QueryColumnIntrospectionQuery(
     query: SqlQuery,
-    context?: Record<string, any>,
-    timeZone?: string,
   ): Limit0QueryColumnIntrospectionQuery {
-    const payload: Limit0QueryColumnIntrospectionQuery = {
+    return {
       query: query.changeLimitValue(0).toString(),
-      context: { ...(context || {}), sqlTimeZone: timeZone ?? 'Etc/UTC' },
       header: true,
       typesHeader: true,
       sqlTypesHeader: true,
     };
-
-    return payload;
   }
 
   static getQueryColumnSampleQuery(query: SqlQuery): SqlQuery {


### PR DESCRIPTION
adds Intropect.decodeLimit0QueryColumnIntrospectionResult which will interpret the results of a limit 0 query with the headers sqlTypesHeader and typesHeader set to true. It will return an array of the column name and the native type unless the sqlType is TIMESTAMP OR BOOLEAN, in which case it will return the sqlType. 

adds getLimit0QueryColumnIntrospectionQuery which will return the payload necessary to make a request to Druid with the proper settings to use decodeLimit0QueryColumnIntrospectionResult. 