### PR TITLE
Redo comparison ops, tidy up introspection functions

### DIFF
--- a/src/filter-pattern/pattern-values.ts
+++ b/src/filter-pattern/pattern-values.ts
@@ -57,12 +57,13 @@ export const VALUES_PATTERN_DEFINITION: FilterPatternDefinition<ValuesFilterPatt
         return;
 
       case 'IN':
+      case 'NOT IN':
         if (lhs instanceof SqlColumn && rhs instanceof SqlRecord) {
           const values = sqlRecordGetLiteralValues(rhs);
           if (values) {
             return {
               type: 'values',
-              negated: xor(ex.negated, negated),
+              negated: xor(ex.hasNot(), negated),
               column: lhs.getName(),
               values,
             };

--- a/src/introspect/introspect.spec.ts
+++ b/src/introspect/introspect.spec.ts
@@ -12,15 +12,9 @@
  * limitations under the License.
  */
 
-import { Column, Introspect, QueryResult, SqlQuery } from '..';
-import { sane } from '../utils';
+import { Column, Introspect, QueryResult } from '..';
 
 describe('Introspect', () => {
-  const emptyQueryResult = new QueryResult({
-    header: [],
-    rows: [],
-  });
-
   describe('.decodeTableIntrospectionResult', () => {
     it('works', () => {
       const queryResult = new QueryResult({
@@ -39,764 +33,101 @@ describe('Introspect', () => {
     });
 
     it('works with empty result', () => {
+      const emptyQueryResult = new QueryResult({
+        header: [],
+        rows: [],
+      });
+
       expect(Introspect.decodeTableIntrospectionResult(emptyQueryResult)).toEqual([]);
     });
   });
 
-  describe('.decodeTableColumnIntrospectionResult', () => {
-    it('works', () => {
-      const queryResult = new QueryResult({
-        header: Column.fromColumnNames(['COLUMN_NAME', 'DATA_TYPE']),
-        rows: [
-          ['__time', 'TIMESTAMP'],
-          ['channel', 'VARCHAR'],
-          ['cityName', 'VARCHAR'],
-          ['comment', 'VARCHAR'],
-          ['count', 'BIGINT'],
-          ['sum_delta', 'BIGINT'],
-          ['sum_deltaBucket', 'BIGINT'],
-          ['user', 'VARCHAR'],
-          ['distinct_thing', 'COMPLEX<HLLSketch>'],
-        ],
-      });
+  describe('.decodeQueryColumnIntrospectionResult', () => {
+    /*
+    The response from doing SELECT * on:
 
-      expect(Introspect.decodeTableColumnIntrospectionResult(queryResult)).toEqual([
+    INSERT INTO "wiki_reshape"
+    SELECT
+      "__time",
+      "channel",
+      "added",
+      "cityName" = 'San Francisco' AS "is_sf",
+      APPROX_COUNT_DISTINCT("user") AS "unique_user_hll",
+      DS_HLL("user") AS "unique_user_ds_hll",
+      DS_THETA("page") AS "theta_page",
+      DS_QUANTILES_SKETCH("commentLength") AS "comment_length_quantile"
+    FROM "wikipedia"
+    GROUP BY 1, 2, 3, 4
+    PARTITIONED BY DAY
+     */
+
+    it('works with all types', () => {
+      const data = [
+        [
+          '__time',
+          'channel',
+          'added',
+          'is_sf',
+          'comment_length_quantile',
+          'theta_page',
+          'unique_user_ds_hll',
+          'unique_user_hll',
+        ],
+        [
+          'LONG',
+          'STRING',
+          'LONG',
+          'LONG',
+          'COMPLEX<quantilesDoublesSketch>',
+          'COMPLEX<thetaSketch>',
+          'COMPLEX<HLLSketch>',
+          'COMPLEX<hyperUnique>',
+        ],
+        ['TIMESTAMP', 'VARCHAR', 'BIGINT', 'BIGINT', 'OTHER', 'OTHER', 'OTHER', 'OTHER'],
+      ];
+
+      const queryResult = QueryResult.fromRawResult(data, true, true, true, true);
+
+      expect(Introspect.decodeQueryColumnIntrospectionResult(queryResult)).toEqual([
         {
           name: '__time',
-          type: 'TIMESTAMP',
+          nativeType: 'LONG',
+          sqlType: 'TIMESTAMP',
         },
         {
           name: 'channel',
-          type: 'VARCHAR',
+          nativeType: 'STRING',
+          sqlType: 'VARCHAR',
         },
         {
-          name: 'cityName',
-          type: 'VARCHAR',
+          name: 'added',
+          nativeType: 'LONG',
+          sqlType: 'BIGINT',
         },
         {
-          name: 'comment',
-          type: 'VARCHAR',
+          name: 'is_sf',
+          nativeType: 'LONG',
+          sqlType: 'BIGINT',
         },
         {
-          name: 'count',
-          type: 'BIGINT',
+          name: 'comment_length_quantile',
+          nativeType: 'COMPLEX<quantilesDoublesSketch>',
+          sqlType: 'OTHER',
         },
         {
-          name: 'sum_delta',
-          type: 'BIGINT',
+          name: 'theta_page',
+          nativeType: 'COMPLEX<thetaSketch>',
+          sqlType: 'OTHER',
         },
         {
-          name: 'sum_deltaBucket',
-          type: 'BIGINT',
+          name: 'unique_user_ds_hll',
+          nativeType: 'COMPLEX<HLLSketch>',
+          sqlType: 'OTHER',
         },
         {
-          name: 'user',
-          type: 'VARCHAR',
-        },
-        {
-          name: 'distinct_thing',
-          type: 'COMPLEX<HLLSketch>',
-        },
-      ]);
-    });
-
-    it('works with empty result', () => {
-      expect(Introspect.decodeTableColumnIntrospectionResult(emptyQueryResult)).toEqual([]);
-    });
-  });
-
-  describe('.decodeColumnTypesFromPlan', () => {
-    it('works when there is only a PLAN', () => {
-      const queryPlanResult = new QueryResult({
-        header: Column.fromColumnNames(['PLAN']),
-        rows: [['DruidQueryRel(query=[...\n...], signature=[{d0:STRING, a0:LONG}])\n']],
-      });
-
-      expect(Introspect.decodeColumnTypesFromPlan(queryPlanResult)).toEqual(['STRING', 'LONG']);
-    });
-
-    it('works when there is more than a PLAN', () => {
-      const queryPlanResult = new QueryResult({
-        header: Column.fromColumnNames(['PLAN', 'RESOURCES']),
-        rows: [
-          [
-            'DruidQueryRel(query=[...\n...], signature=[{d0:STRING, a0:LONG}])\n',
-            '[{"name":"wikipedia","type":"DATASOURCE"}]',
-          ],
-        ],
-      });
-
-      expect(Introspect.decodeColumnTypesFromPlan(queryPlanResult)).toEqual(['STRING', 'LONG']);
-    });
-
-    it('works with empty result', () => {
-      expect(Introspect.decodeColumnTypesFromPlan(emptyQueryResult)).toEqual([]);
-    });
-  });
-
-  describe('.getQueryColumnSampleQuery', () => {
-    expect(
-      String(
-        Introspect.getQueryColumnSampleQuery(
-          SqlQuery.parse(sane`
-            SELECT added + 1, * FROM "wikipedia"
-            Union All
-            SELECT * FROM "wiki"
-          `),
-        ),
-      ),
-    ).toEqual(sane`
-      SELECT added + 1, * FROM "wikipedia"
-      Union All
-      SELECT * FROM "wiki"
-      LIMIT 1
-    `);
-  });
-
-  describe('.decodeQueryColumnIntrospectionResult (native)', () => {
-    it('works with empty result', () => {
-      expect(Introspect.decodeQueryColumnIntrospectionResult(emptyQueryResult)).toEqual([]);
-    });
-
-    it('works with all columns having good names', () => {
-      const query = SqlQuery.parse(sane`
-        SELECT
-          __time,
-          cityName,
-          COUNT(*) AS "Count"
-        FROM wikipedia
-        GROUP BY 1
-        ORDER BY 2 DESC
-      `);
-
-      const queryPlanResult = new QueryResult({
-        sqlQuery: Introspect.getQueryColumnIntrospectionQuery(query),
-        header: Column.fromColumnNames(['PLAN']),
-        rows: [['DruidQueryRel(query=[...\n...], signature=[{d0:LONG, d1:STRING, a0:LONG}])\n']],
-      });
-
-      expect(Introspect.decodeQueryColumnIntrospectionResult(queryPlanResult)).toEqual([
-        {
-          name: '__time',
-          type: 'TIMESTAMP',
-        },
-        {
-          name: 'cityName',
-          type: 'STRING',
-        },
-        {
-          name: 'Count',
-          type: 'LONG',
-        },
-      ]);
-    });
-
-    it('works with some column not having good names', () => {
-      const query = SqlQuery.parse(sane`
-        SELECT
-          cityName,
-          COUNT(*)
-        FROM wikipedia
-        GROUP BY 1
-        ORDER BY 2 DESC
-      `);
-
-      const queryPlanResult = new QueryResult({
-        sqlQuery: Introspect.getQueryColumnIntrospectionQuery(query),
-        header: Column.fromColumnNames(['PLAN']),
-        rows: [['DruidQueryRel(query=[...\n...], signature=[{d0:STRING, a0:LONG}])\n']],
-      });
-
-      expect(Introspect.decodeQueryColumnIntrospectionResult(queryPlanResult)).toEqual([
-        {
-          name: 'cityName',
-          type: 'STRING',
-        },
-      ]);
-    });
-
-    it('fails with star without sample', () => {
-      const query = SqlQuery.parse(sane`
-        SELECT cityName, * FROM wikipedia
-      `);
-
-      const queryPlanResult = new QueryResult({
-        sqlQuery: Introspect.getQueryColumnIntrospectionQuery(query),
-        header: Column.fromColumnNames(['PLAN']),
-        rows: [['DruidQueryRel(query=[...\n...], signature=[{d0:STRING, a0:LONG, a1:LONG}])\n']],
-      });
-
-      expect(() => Introspect.decodeQueryColumnIntrospectionResult(queryPlanResult)).toThrow(
-        'a query with a star must have sampleRowResult set',
-      );
-    });
-
-    it('works with star', () => {
-      const query = SqlQuery.parse(sane`
-        SELECT "time", cityName, added + 1, * FROM wikipedia
-      `);
-
-      const queryPlanResult = new QueryResult({
-        sqlQuery: Introspect.getQueryColumnIntrospectionQuery(query),
-        header: Column.fromColumnNames(['PLAN']),
-        rows: [
-          [
-            'DruidQueryRel(query=[...\n...], signature=[{d0:LONG, d1:STRING, a0:LONG, a1:LONG, a1:LONG}])\n',
-          ],
-        ],
-      });
-
-      const sampleResult = new QueryResult({
-        header: Column.fromColumnNames(['time', 'cityName', 'EXPR$0', 'delta', 'deleted']),
-        rows: [[new Date('2020-01-01T00:00:00'), 'SF', 1, 4, true]],
-      });
-
-      expect(
-        Introspect.decodeQueryColumnIntrospectionResult(queryPlanResult, sampleResult),
-      ).toEqual([
-        {
-          name: 'time',
-          type: 'TIMESTAMP',
-        },
-        {
-          name: 'cityName',
-          type: 'STRING',
-        },
-        {
-          name: 'delta',
-          type: 'LONG',
-        },
-        {
-          name: 'deleted',
-          type: 'BOOLEAN',
-        },
-      ]);
-    });
-
-    it('works with star with fancy names', () => {
-      const query = SqlQuery.parse(sane`
-        SELECT "time", cityName, added + 1, * FROM wikipedia
-      `);
-
-      const queryPlanResult = new QueryResult({
-        sqlQuery: Introspect.getQueryColumnIntrospectionQuery(query),
-        header: Column.fromColumnNames(['PLAN']),
-        rows: [
-          [
-            'DruidQueryRel(query=[...\n...], signature=[{Hello World:LONG, A-B:STRING, Россия:LONG, ö:LONG, hello, world:LONG}])\n',
-          ],
-        ],
-      });
-
-      const sampleResult = new QueryResult({
-        header: Column.fromColumnNames(['time', 'cityName', 'EXPR$0', 'delta', 'deleted']),
-        rows: [[new Date('2020-01-01T00:00:00'), 'SF', 1, 4, true]],
-      });
-
-      expect(
-        Introspect.decodeQueryColumnIntrospectionResult(queryPlanResult, sampleResult),
-      ).toEqual([
-        {
-          name: 'time',
-          type: 'TIMESTAMP',
-        },
-        {
-          name: 'cityName',
-          type: 'STRING',
-        },
-        {
-          name: 'delta',
-          type: 'LONG',
-        },
-        {
-          name: 'deleted',
-          type: 'BOOLEAN',
-        },
-      ]);
-    });
-
-    it('works with a JOIN query', () => {
-      const query = SqlQuery.parse(sane`
-        SELECT
-          browser,
-          lookup.browser_maker.v AS "maker",
-          COUNT(*) AS "Count"
-        FROM kttm
-        LEFT JOIN lookup.browser_maker ON lookup.browser_maker.k = kttm.browser
-        GROUP BY 1, 2
-        ORDER BY 3 DESC
-      `);
-
-      const queryPlanResult = new QueryResult({
-        sqlQuery: Introspect.getQueryColumnIntrospectionQuery(query),
-        header: Column.fromColumnNames(['PLAN']),
-        rows: [
-          [
-            '\nDruidJoinQueryRel(condition=[=($4, $29)], joinType=[left], query=[{ ... }], signature=[{d0:STRING, d1:STRING, a0:LONG}]) DruidQueryRel(query=[{ ... }], signature=[{__time:LONG, adblock_list:STRING, agent_category:STRING, agent_type:STRING, browser:STRING, browser_version:STRING, city:STRING, continent:STRING, country:STRING, event_subtype:STRING, event_type:STRING, forwarded_for:STRING, language:STRING, loaded_image:STRING, number:LONG, os:STRING, path:STRING, platform:STRING, referrer:STRING, referrer_host:STRING, region:STRING, remote_address:STRING, screen:STRING, session:STRING, session_length:LONG, timezone:STRING, timezone_offset:LONG, version:STRING, window:STRING}]) DruidQueryRel(query=[{ ... }], signature=[{k:STRING, v:STRING}])\n',
-          ],
-        ],
-      });
-
-      expect(Introspect.decodeQueryColumnIntrospectionResult(queryPlanResult)).toEqual([
-        {
-          name: 'browser',
-          type: 'STRING',
-        },
-        {
-          name: 'maker',
-          type: 'STRING',
-        },
-        {
-          name: 'Count',
-          type: 'LONG',
-        },
-      ]);
-    });
-
-    it('works with some columns having complex data types', () => {
-      const query = SqlQuery.parse(sane`
-        SELECT * FROM wikipedia
-      `);
-
-      const queryPlanResult = new QueryResult({
-        sqlQuery: Introspect.getQueryColumnIntrospectionQuery(query),
-        header: Column.fromColumnNames(['PLAN']),
-        rows: [
-          [
-            'DruidQueryRel(query=[...\n...], signature=[{d0:LONG, d1:STRING, a0:COMPLEX<HLLSketch>, a1:LONG, a1:LONG}])\n',
-          ],
-        ],
-      });
-
-      const sampleResult = new QueryResult({
-        header: Column.fromColumnNames([
-          'time',
-          'cityName',
-          'distinct_cityName',
-          'delta',
-          'deleted',
-        ]),
-        rows: [[new Date('2020-01-01T00:00:00'), 'SF', 1, 4, true]],
-      });
-
-      expect(
-        Introspect.decodeQueryColumnIntrospectionResult(queryPlanResult, sampleResult),
-      ).toEqual([
-        {
-          name: 'time',
-          type: 'TIMESTAMP',
-        },
-        {
-          name: 'cityName',
-          type: 'STRING',
-        },
-        {
-          name: 'distinct_cityName',
-          type: 'COMPLEX<HLLSketch>',
-        },
-        {
-          name: 'delta',
-          type: 'LONG',
-        },
-        {
-          name: 'deleted',
-          type: 'BOOLEAN',
-        },
-      ]);
-    });
-  });
-
-  describe('.decodeQueryColumnIntrospectionResult (json)', () => {
-    it('works with empty result', () => {
-      expect(Introspect.decodeQueryColumnIntrospectionResult(emptyQueryResult)).toEqual([]);
-    });
-
-    it('works with all columns having good names', () => {
-      const query = SqlQuery.parse(sane`
-        SELECT
-          __time,
-          cityName,
-          COUNT(*) AS "Count"
-        FROM wikipedia
-        GROUP BY 1
-        ORDER BY 2 DESC
-      `);
-
-      const queryPlanResult = new QueryResult({
-        sqlQuery: Introspect.getQueryColumnIntrospectionQuery(query),
-        header: Column.fromColumnNames(['PLAN']),
-        rows: [
-          [
-            '[{"query":{},"signature":[{"name":"__time","type":"LONG"},{"name":"cityName","type":"STRING"},{"name":"Count","type":"LONG"}]}]',
-          ],
-        ],
-      });
-
-      expect(Introspect.decodeQueryColumnIntrospectionResult(queryPlanResult)).toEqual([
-        {
-          name: '__time',
-          type: 'TIMESTAMP',
-        },
-        {
-          name: 'cityName',
-          type: 'STRING',
-        },
-        {
-          name: 'Count',
-          type: 'LONG',
-        },
-      ]);
-    });
-
-    it('works with some column not having good names', () => {
-      const query = SqlQuery.parse(sane`
-        SELECT
-          cityName,
-          COUNT(*)
-        FROM wikipedia
-        GROUP BY 1
-        ORDER BY 2 DESC
-      `);
-
-      const queryPlanResult = new QueryResult({
-        sqlQuery: Introspect.getQueryColumnIntrospectionQuery(query),
-        header: Column.fromColumnNames(['PLAN']),
-        rows: [
-          [
-            '[{"query":{},"signature":[{"name":"cityName","type":"STRING"},{"name":"Count","type":"LONG"}]}]',
-          ],
-        ],
-      });
-
-      expect(Introspect.decodeQueryColumnIntrospectionResult(queryPlanResult)).toEqual([
-        {
-          name: 'cityName',
-          type: 'STRING',
-        },
-      ]);
-    });
-
-    it('fails with star without sample', () => {
-      const query = SqlQuery.parse(sane`
-        SELECT cityName, * FROM wikipedia
-      `);
-
-      const queryPlanResult = new QueryResult({
-        sqlQuery: Introspect.getQueryColumnIntrospectionQuery(query),
-        header: Column.fromColumnNames(['PLAN']),
-        rows: [
-          [
-            '[{"query":{},"signature":[{"name":"__time","type":"LONG"},{"name":"cityName","type":"STRING"},{"name":"Count","type":"LONG"}]}]',
-          ],
-        ],
-      });
-
-      expect(() => Introspect.decodeQueryColumnIntrospectionResult(queryPlanResult)).toThrow(
-        'a query with a star must have sampleRowResult set',
-      );
-    });
-
-    it('works with star', () => {
-      const query = SqlQuery.parse(sane`
-        SELECT "time", cityName, added + 1, * FROM wikipedia
-      `);
-
-      const queryPlanResult = new QueryResult({
-        sqlQuery: Introspect.getQueryColumnIntrospectionQuery(query),
-        header: Column.fromColumnNames(['PLAN']),
-        rows: [
-          [
-            '[{"query":{},"signature":[{"name":"__time","type":"LONG"},{"name":"cityName","type":"STRING"},{"name":"EXPR$0","type":"LONG"},{"name":"delta","type":"LONG"},{"name":"deleted","type":"LONG"}]}]',
-          ],
-        ],
-      });
-
-      const sampleResult = new QueryResult({
-        header: Column.fromColumnNames(['time', 'cityName', 'EXPR$0', 'delta', 'deleted']),
-        rows: [[new Date('2020-01-01T00:00:00'), 'SF', 1, 4, true]],
-      });
-
-      expect(
-        Introspect.decodeQueryColumnIntrospectionResult(queryPlanResult, sampleResult),
-      ).toEqual([
-        {
-          name: 'time',
-          type: 'TIMESTAMP',
-        },
-        {
-          name: 'cityName',
-          type: 'STRING',
-        },
-        {
-          name: 'delta',
-          type: 'LONG',
-        },
-        {
-          name: 'deleted',
-          type: 'BOOLEAN',
-        },
-      ]);
-    });
-
-    it('works with star with fancy names', () => {
-      const query = SqlQuery.parse(sane`
-        SELECT "time", cityName, added + 1, * FROM wikipedia
-      `);
-
-      const queryPlanResult = new QueryResult({
-        sqlQuery: Introspect.getQueryColumnIntrospectionQuery(query),
-        header: Column.fromColumnNames(['PLAN']),
-        rows: [
-          [
-            '[{"query":{},"signature":[{"name":"Hello World","type":"LONG"},{"name":"A-B","type":"STRING"},{"name":"Россия","type":"LONG"},{"name":"ö","type":"LONG"},{"name":"hello, world","type":"LONG"}]}]',
-          ],
-        ],
-      });
-
-      const sampleResult = new QueryResult({
-        header: Column.fromColumnNames(['time', 'cityName', 'EXPR$0', 'delta', 'deleted']),
-        rows: [[new Date('2020-01-01T00:00:00'), 'SF', 1, 4, true]],
-      });
-
-      expect(
-        Introspect.decodeQueryColumnIntrospectionResult(queryPlanResult, sampleResult),
-      ).toEqual([
-        {
-          name: 'time',
-          type: 'TIMESTAMP',
-        },
-        {
-          name: 'cityName',
-          type: 'STRING',
-        },
-        {
-          name: 'delta',
-          type: 'LONG',
-        },
-        {
-          name: 'deleted',
-          type: 'BOOLEAN',
-        },
-      ]);
-    });
-
-    it('works with a JOIN query', () => {
-      const query = SqlQuery.parse(sane`
-        SELECT
-          browser,
-          lookup.browser_maker.v AS "maker",
-          COUNT(*) AS "Count"
-        FROM kttm
-        LEFT JOIN lookup.browser_maker ON lookup.browser_maker.k = kttm.browser
-        GROUP BY 1, 2
-        ORDER BY 3 DESC
-      `);
-
-      const queryPlanResult = new QueryResult({
-        sqlQuery: Introspect.getQueryColumnIntrospectionQuery(query),
-        header: Column.fromColumnNames(['PLAN']),
-        rows: [
-          [
-            '[{"query":{},"signature":[{"name":"browser","type":"STRING"},{"name":"maker","type":"STRING"},{"name":"Count","type":"LONG"}]}]',
-          ],
-        ],
-      });
-
-      expect(Introspect.decodeQueryColumnIntrospectionResult(queryPlanResult)).toEqual([
-        {
-          name: 'browser',
-          type: 'STRING',
-        },
-        {
-          name: 'maker',
-          type: 'STRING',
-        },
-        {
-          name: 'Count',
-          type: 'LONG',
-        },
-      ]);
-    });
-
-    it('works with some columns having complex data types', () => {
-      const query = SqlQuery.parse(sane`
-        SELECT * FROM wikipedia
-      `);
-
-      const queryPlanResult = new QueryResult({
-        sqlQuery: Introspect.getQueryColumnIntrospectionQuery(query),
-        header: Column.fromColumnNames(['PLAN']),
-        rows: [
-          [
-            '[{"query":{},"signature":[{"name":"time","type":"LONG"},{"name":"cityName","type":"STRING"},{"name":"distinct_cityName","type":"COMPLEX<HLLSketch>"},{"name":"delta","type":"LONG"},{"name":"deleted","type":"LONG"}]}]',
-          ],
-        ],
-      });
-
-      const sampleResult = new QueryResult({
-        header: Column.fromColumnNames([
-          'time',
-          'cityName',
-          'distinct_cityName',
-          'delta',
-          'deleted',
-        ]),
-        rows: [[new Date('2020-01-01T00:00:00'), 'SF', 1, 4, true]],
-      });
-
-      expect(
-        Introspect.decodeQueryColumnIntrospectionResult(queryPlanResult, sampleResult),
-      ).toEqual([
-        {
-          name: 'time',
-          type: 'TIMESTAMP',
-        },
-        {
-          name: 'cityName',
-          type: 'STRING',
-        },
-        {
-          name: 'distinct_cityName',
-          type: 'COMPLEX<HLLSketch>',
-        },
-        {
-          name: 'delta',
-          type: 'LONG',
-        },
-        {
-          name: 'deleted',
-          type: 'BOOLEAN',
-        },
-      ]);
-    });
-  });
-
-  describe('.decodeLimit0QueryColumnIntrospectionResult', () => {
-    it('works with all types', () => {
-      const queryResult = new QueryResult({
-        header: Column.fromColumnNames([
-          '__time',
-          'isRobot',
-          'country',
-          'comment',
-          'count',
-          'sum_delta',
-          'sum_deltaBucket',
-          'user',
-          'comment_length',
-          'someNumber',
-          'someNumber',
-          'someNumber',
-        ]),
-        rows: [
-          [
-            { type: 'LONG', sqlType: 'TIMESTAMP' },
-            { type: 'LONG', sqlType: 'BOOLEAN' },
-            { type: 'STRING', sqlType: 'VARCHAR' },
-            { type: 'STRING', sqlType: 'CHAR' },
-            { type: 'LONG', sqlType: 'LONG' },
-            { type: 'DOUBLE', sqlType: 'DECIMAL' },
-            { type: 'DOUBLE', sqlType: 'REAL' },
-            { type: 'DOUBLE', sqlType: 'DOUBLE' },
-            { type: 'FLOAT', sqlType: 'FLOAT' },
-            { type: 'LONG', sqlType: 'TINYINT' },
-            { type: 'LONG', sqlType: 'SMALLINT' },
-            { type: 'LONG', sqlType: 'BIGINT' },
-          ],
-        ],
-      });
-
-      expect(Introspect.decodeLimit0QueryColumnIntrospectionResult(queryResult)).toEqual([
-        {
-          name: '__time',
-          type: 'TIMESTAMP',
-        },
-        {
-          name: 'isRobot',
-          type: 'BOOLEAN',
-        },
-        {
-          name: 'country',
-          type: 'STRING',
-        },
-        {
-          name: 'comment',
-          type: 'STRING',
-        },
-        {
-          name: 'count',
-          type: 'LONG',
-        },
-        {
-          name: 'sum_delta',
-          type: 'DOUBLE',
-        },
-        {
-          name: 'sum_deltaBucket',
-          type: 'DOUBLE',
-        },
-        {
-          name: 'user',
-          type: 'DOUBLE',
-        },
-        {
-          name: 'comment_length',
-          type: 'FLOAT',
-        },
-        {
-          name: 'someNumber',
-          type: 'LONG',
-        },
-        {
-          name: 'someNumber',
-          type: 'LONG',
-        },
-        {
-          name: 'someNumber',
-          type: 'LONG',
-        },
-      ]);
-    });
-    it('works with some columns having complex data types', () => {
-      const sampleResult = new QueryResult({
-        header: Column.fromColumnNames([
-          'time',
-          'cityName',
-          'distinct_cityName',
-          'delta',
-          'deleted',
-        ]),
-        rows: [
-          [
-            { type: 'LONG', sqlType: 'TIMESTAMP' },
-            { type: 'STRING', sqlType: 'VARCHAR' },
-            { type: 'COMPLEX<HLLSketch>', sqlType: 'COMPLEX<HLLSketch>_' },
-            { type: 'LONG', sqlType: 'BIGINT' },
-            { type: 'LONG', sqlType: 'BOOLEAN' },
-          ],
-        ],
-      });
-
-      expect(Introspect.decodeLimit0QueryColumnIntrospectionResult(sampleResult)).toEqual([
-        {
-          name: 'time',
-          type: 'TIMESTAMP',
-        },
-        {
-          name: 'cityName',
-          type: 'STRING',
-        },
-        {
-          name: 'distinct_cityName',
-          type: 'COMPLEX<HLLSketch>',
-        },
-        {
-          name: 'delta',
-          type: 'LONG',
-        },
-        {
-          name: 'deleted',
-          type: 'BOOLEAN',
+          name: 'unique_user_hll',
+          nativeType: 'COMPLEX<hyperUnique>',
+          sqlType: 'OTHER',
         },
       ]);
     });

--- a/src/introspect/introspect.ts
+++ b/src/introspect/introspect.ts
@@ -12,30 +12,19 @@
  * limitations under the License.
  */
 
-import { QueryResult } from '../query-result/query-result';
-import { SqlLiteral, SqlQuery, SqlTable } from '../sql';
-import { filterMap } from '../utils';
+import { Column, QueryResult } from '../query-result';
+import { SqlQuery, SqlTable } from '../sql';
+import { dedupe } from '../utils';
 
 export interface TableInfo {
   name: string;
 }
 
-export interface ColumnInfo {
-  name: string;
-  type: string;
-}
-
-interface Limit0QueryColumnIntrospectionQuery {
+interface QueryColumnIntrospectionQuery {
   query: string;
-  header?: true;
-  typesHeader?: true;
-  sqlTypesHeader?: true;
-}
-
-function guessTypeFromValue(v: any): string | undefined {
-  if (v instanceof Date) return 'TIMESTAMP';
-  if (v === true || v === false) return 'BOOLEAN';
-  return;
+  header: true;
+  typesHeader: true;
+  sqlTypesHeader: true;
 }
 
 export class Introspect {
@@ -48,167 +37,31 @@ export class Introspect {
     return queryResult.rows.map(r => ({ name: r[0] }));
   }
 
-  static getTableColumnIntrospectionQuery(thing: SqlTable | string): SqlQuery {
-    let tableName: string;
-    if (thing instanceof SqlTable) {
-      tableName = thing.getName();
+  static getQueryColumnIntrospectionQuery(query: SqlQuery | SqlTable): SqlQuery {
+    if (query instanceof SqlTable) {
+      return SqlQuery.create(query).changeLimitValue(0);
     } else {
-      tableName = thing;
+      return query.changeLimitValue(0);
     }
-    return SqlQuery.parse(
-      `SELECT COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = 'druid' AND TABLE_NAME = ${SqlLiteral.create(
-        tableName,
-      )}`,
-    );
   }
 
-  static decodeTableColumnIntrospectionResult(queryResult: QueryResult): ColumnInfo[] {
-    if (queryResult.isEmpty()) return [];
-    if (queryResult.getHeaderNames().join(',') !== 'COLUMN_NAME,DATA_TYPE') {
-      throw new Error('invalid result shape, bad header');
-    }
-    return queryResult.rows.map(r => ({ name: r[0], type: r[1] }));
-  }
-
-  static getQueryColumnIntrospectionQuery(query: SqlQuery): SqlQuery {
-    return query.makeExplain();
-  }
-
-  static getLimit0QueryColumnIntrospectionQuery(
-    query: SqlQuery,
-  ): Limit0QueryColumnIntrospectionQuery {
+  static getQueryColumnIntrospectionPayload(
+    query: SqlQuery | SqlTable,
+  ): QueryColumnIntrospectionQuery {
     return {
-      query: query.changeLimitValue(0).toString(),
+      query: Introspect.getQueryColumnIntrospectionQuery(query).toString(),
       header: true,
       typesHeader: true,
       sqlTypesHeader: true,
     };
   }
 
-  static getQueryColumnSampleQuery(query: SqlQuery): SqlQuery {
-    return query.changeLimitValue(1);
-  }
-
-  static decodeColumnTypesFromPlan(queryPlanResult: QueryResult): string[] {
-    if (queryPlanResult.isEmpty()) return [];
-    const { rows } = queryPlanResult;
-    if (queryPlanResult.getHeaderNames()[0] !== 'PLAN') {
-      throw new Error('invalid result shape, bad header');
-    }
-    if (rows.length !== 1) throw new Error('invalid result shape, bad number of results');
-
-    const plan = rows[0]![0];
-    let jsonPlan: { signature: { name: string; type: string }[] }[] | undefined;
-
-    try {
-      // Try to parse it as a JSON plan first
-      jsonPlan = JSON.parse(plan);
-    } catch {
-      // Fall back to a native plan
-      const m = plan.match(/ signature=\[\{([^}]*)}]/m);
-      if (!m) throw new Error('could not find signature');
-
-      return m[1].match(/:[A-Z]+(?:<[A-Za-z]+>)?(?:, |$)/g).map((t: string) => {
-        // Will match something like ':LONG, ' or ':LONG'
-        return t.replace(/[:, ]/g, '');
-      });
-    }
-
-    if (!Array.isArray(jsonPlan) || jsonPlan.length === 0) {
-      throw new Error('could not find signature in JSON plan');
-    }
-    const signature = jsonPlan[0]!.signature;
-    if (!signature) throw new Error('could not find signature in JSON plan');
-    return signature.map(s => s.type);
-  }
-
-  static decodeLimit0QueryColumnIntrospectionResult(sampleRowResult?: QueryResult): ColumnInfo[] {
-    const types = sampleRowResult?.rows[0];
-
-    if (!sampleRowResult || !types) return [];
-
-    if (types.length !== sampleRowResult.header.length) {
-      throw new Error('invalid result shape, bad header');
-    }
-
-    return filterMap(sampleRowResult.header, (column, i) => {
-      const columnName = column.name;
-      if (SqlQuery.isPhonyOutputName(columnName)) return;
-      const type = types[i];
-      if (!type) {
-        return;
-      }
-      const columnType =
-        type.sqlType === 'BOOLEAN' || type.sqlType === 'TIMESTAMP' ? type.sqlType : type.type;
-      return { name: columnName, type: columnType };
-    });
-  }
-
-  static decodeQueryColumnIntrospectionResult(
-    queryPlanResult: QueryResult,
-    sampleRowResult?: QueryResult,
-  ): ColumnInfo[] {
-    const { sqlQuery } = queryPlanResult;
-    if (queryPlanResult.isEmpty()) return [];
-    if (!sqlQuery) throw new Error('must have a sqlQuery');
-    const types = Introspect.decodeColumnTypesFromPlan(queryPlanResult);
-
-    if (sampleRowResult) {
-      if (sampleRowResult.header.length !== types.length) {
-        throw new Error(
-          `number of columns in the sample row (${sampleRowResult.header.length}) does not match the number of types (${types.length})`,
-        );
-      }
-
-      const sampleRow = sampleRowResult.rows[0];
-      return filterMap(sampleRowResult.header, (column, i) => {
-        const columnName = column.name;
-        if (SqlQuery.isPhonyOutputName(columnName)) return;
-
-        let type = sampleRow ? guessTypeFromValue(sampleRow[i]) : undefined;
-        if (!type) {
-          type = types[i];
-          if (!type) return;
-          if (columnName === '__time' && type === 'LONG') {
-            type = 'TIMESTAMP';
-          }
-        }
-
-        return { name: columnName, type };
-      });
-    } else {
-      if (sqlQuery.hasStarInSelect()) {
-        throw new Error('a query with a star must have sampleRowResult set');
-      }
-
-      const outputColumns = sqlQuery.getOutputColumns();
-      if (outputColumns.length !== types.length) {
-        throw new Error('number of output columns does not match the number of types');
-      }
-
-      return filterMap(outputColumns, (name, i) => {
-        if (!sqlQuery.isRealOutputColumnAtSelectIndex(i)) return;
-        let type = types[i];
-        if (!type) return;
-        if (name === '__time' && type === 'LONG') {
-          type = 'TIMESTAMP';
-        }
-        return { name: String(name), type };
-      });
-    }
-  }
-
-  static decodeColumnIntrospectionResult(
-    queryResult: QueryResult,
-    sampleRowResult?: QueryResult,
-  ): ColumnInfo[] {
-    const headerNames = queryResult.getHeaderNames();
-    if (headerNames[0] === 'COLUMN_NAME' && headerNames[1] === 'DATA_TYPE') {
-      return Introspect.decodeTableColumnIntrospectionResult(queryResult);
-    } else if (headerNames[0] === 'PLAN') {
-      return Introspect.decodeQueryColumnIntrospectionResult(queryResult, sampleRowResult);
-    } else {
-      throw new Error(`unknown header shape: '${headerNames.join("', '")}'`);
-    }
+  static decodeQueryColumnIntrospectionResult(headerOnlyResult: QueryResult): Column[] {
+    // Remove any column that does not have a "real" name as it can not be referenced
+    // Deduplicate columns, taking only the first one if there are several functions with the same name
+    return dedupe(
+      headerOnlyResult.header.filter(column => !SqlQuery.isPhonyOutputName(column.name)),
+      column => column.name,
+    );
   }
 }

--- a/src/query-result/index.ts
+++ b/src/query-result/index.ts
@@ -12,11 +12,5 @@
  * limitations under the License.
  */
 
-/* eslint-disable simple-import-sort/exports */
-export * from './utils';
-export * from './sql';
-export * from './shortcuts';
-export * from './introspect/introspect';
+export * from './column';
 export * from './query-result';
-export * from './query-runner/query-runner';
-export * from './filter-pattern';

--- a/src/query-runner/query-runner.ts
+++ b/src/query-runner/query-runner.ts
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import { QueryResult } from '../query-result/query-result';
+import { QueryResult } from '../query-result';
 import { SqlQuery } from '../sql';
 
 import { CancelToken } from './cancel-token';

--- a/src/sql/sql-base.ts
+++ b/src/sql/sql-base.ts
@@ -118,7 +118,6 @@ export type KeywordName =
   | 'join'
   | 'joinType'
   | 'limit'
-  | 'not'
   | 'offset'
   | 'on'
   | 'op'
@@ -143,7 +142,6 @@ export type KeywordName =
 export type SpaceName =
   | 'final'
   | 'initial'
-  | 'not'
   | 'postAnd'
   | 'postArguments'
   | 'postArrow'

--- a/src/sql/sql-comparison/sql-comparison.spec.ts
+++ b/src/sql/sql-comparison/sql-comparison.spec.ts
@@ -44,19 +44,6 @@ describe('SqlComparison', () => {
       `(browser, country) IN (ROW ('Chr' || 'ome', 'United States'), ('Firefox', 'Israel'))`,
       `(1, 2) IN (VALUES   (1, 1 + 1),(2, 1 + 1))`,
 
-      "''  similar to ''",
-      "'a' similar to 'a'",
-      "'a' similar to 'b'",
-      "'a' similar to 'A'",
-      "'a' similar to 'a_'",
-      "'a' similar to '_a'",
-      "'a' similar to '%a'",
-      "'a' similar to '%a%'",
-      "'a' similar to 'a%'",
-      "'ab'   similar to 'a_'",
-      "'ab' not similar to 'a_'",
-      "'aabc' not similar to 'ab*c+d'",
-
       '2 between 1 and 3',
       '2 between 3 and 2',
       '2 between symmetric 3 and 2',
@@ -137,7 +124,6 @@ describe('SqlComparison', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": false,
         "op": ">",
         "parens": undefined,
         "rhs": SqlColumn {
@@ -182,7 +168,6 @@ describe('SqlComparison', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": false,
         "op": "=",
         "parens": undefined,
         "rhs": SqlLiteral {
@@ -225,7 +210,6 @@ describe('SqlComparison', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": false,
         "op": "=",
         "parens": undefined,
         "rhs": SqlQuery {
@@ -434,7 +418,6 @@ describe('SqlComparison', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": false,
         "op": "IS",
         "parens": undefined,
         "rhs": SqlLiteral {
@@ -463,8 +446,7 @@ describe('SqlComparison', () => {
       SqlComparison {
         "decorator": undefined,
         "keywords": Object {
-          "not": "NOT",
-          "op": "IS",
+          "op": "IS   NOT",
         },
         "lhs": SqlColumn {
           "keywords": Object {},
@@ -477,8 +459,7 @@ describe('SqlComparison', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": true,
-        "op": "IS",
+        "op": "IS NOT",
         "parens": undefined,
         "rhs": SqlLiteral {
           "keywords": Object {},
@@ -489,8 +470,7 @@ describe('SqlComparison', () => {
           "value": null,
         },
         "spacing": Object {
-          "not": "    ",
-          "postOp": "   ",
+          "postOp": "    ",
           "preOp": "  ",
         },
         "type": "comparison",
@@ -520,7 +500,6 @@ describe('SqlComparison', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": false,
         "op": "IN",
         "parens": undefined,
         "rhs": SqlRecord {
@@ -578,7 +557,6 @@ describe('SqlComparison', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": false,
         "op": "IN",
         "parens": undefined,
         "rhs": SqlRecord {
@@ -676,8 +654,7 @@ describe('SqlComparison', () => {
       SqlComparison {
         "decorator": undefined,
         "keywords": Object {
-          "not": "NOT",
-          "op": "IN",
+          "op": "NOT IN",
         },
         "lhs": SqlColumn {
           "keywords": Object {},
@@ -690,8 +667,7 @@ describe('SqlComparison', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": true,
-        "op": "IN",
+        "op": "NOT IN",
         "parens": undefined,
         "rhs": SqlRecord {
           "expressions": SeparatedArray {
@@ -771,7 +747,6 @@ describe('SqlComparison', () => {
           "type": "record",
         },
         "spacing": Object {
-          "not": " ",
           "postOp": " ",
           "preOp": " ",
         },
@@ -802,7 +777,6 @@ describe('SqlComparison', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": false,
         "op": "IN",
         "parens": undefined,
         "rhs": SqlQuery {
@@ -918,8 +892,7 @@ describe('SqlComparison', () => {
       SqlComparison {
         "decorator": undefined,
         "keywords": Object {
-          "not": "NOT",
-          "op": "IN",
+          "op": "NOT IN",
         },
         "lhs": SqlColumn {
           "keywords": Object {},
@@ -932,8 +905,7 @@ describe('SqlComparison', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": true,
-        "op": "IN",
+        "op": "NOT IN",
         "parens": undefined,
         "rhs": SqlQuery {
           "clusteredByClause": undefined,
@@ -1027,7 +999,6 @@ describe('SqlComparison', () => {
           "withClause": undefined,
         },
         "spacing": Object {
-          "not": " ",
           "postOp": " ",
           "preOp": " ",
         },
@@ -1091,7 +1062,6 @@ describe('SqlComparison', () => {
           },
           "type": "record",
         },
-        "negated": false,
         "op": "IN",
         "parens": undefined,
         "rhs": SqlRecord {
@@ -1249,7 +1219,6 @@ describe('SqlComparison', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": false,
         "op": "BETWEEN",
         "parens": undefined,
         "rhs": SqlBetweenPart {
@@ -1304,8 +1273,7 @@ describe('SqlComparison', () => {
       SqlComparison {
         "decorator": undefined,
         "keywords": Object {
-          "not": "NOT",
-          "op": "BETWEEN",
+          "op": "NOT BETWEEN",
         },
         "lhs": SqlColumn {
           "keywords": Object {},
@@ -1318,8 +1286,7 @@ describe('SqlComparison', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": true,
-        "op": "BETWEEN",
+        "op": "NOT BETWEEN",
         "parens": undefined,
         "rhs": SqlBetweenPart {
           "end": SqlColumn {
@@ -1358,7 +1325,6 @@ describe('SqlComparison', () => {
           "type": "betweenPart",
         },
         "spacing": Object {
-          "not": " ",
           "postOp": " ",
           "preOp": " ",
         },
@@ -1389,7 +1355,6 @@ describe('SqlComparison', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": false,
         "op": "LIKE",
         "parens": undefined,
         "rhs": SqlLiteral {
@@ -1418,8 +1383,7 @@ describe('SqlComparison', () => {
       SqlComparison {
         "decorator": undefined,
         "keywords": Object {
-          "not": "NOT",
-          "op": "LIKE",
+          "op": "NOT LIKE",
         },
         "lhs": SqlColumn {
           "keywords": Object {},
@@ -1432,8 +1396,7 @@ describe('SqlComparison', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": true,
-        "op": "LIKE",
+        "op": "NOT LIKE",
         "parens": undefined,
         "rhs": SqlLiteral {
           "keywords": Object {},
@@ -1444,7 +1407,6 @@ describe('SqlComparison', () => {
           "value": "%A%",
         },
         "spacing": Object {
-          "not": " ",
           "postOp": " ",
           "preOp": " ",
         },
@@ -1462,8 +1424,7 @@ describe('SqlComparison', () => {
       SqlComparison {
         "decorator": undefined,
         "keywords": Object {
-          "not": "NOT",
-          "op": "LIKE",
+          "op": "NOT LIKE",
         },
         "lhs": SqlMulti {
           "args": SeparatedArray {
@@ -1505,8 +1466,7 @@ describe('SqlComparison', () => {
           "spacing": Object {},
           "type": "multi",
         },
-        "negated": true,
-        "op": "LIKE",
+        "op": "NOT LIKE",
         "parens": undefined,
         "rhs": SqlLikePart {
           "escape": SqlMulti {
@@ -1588,7 +1548,6 @@ describe('SqlComparison', () => {
           "type": "likePart",
         },
         "spacing": Object {
-          "not": " ",
           "postOp": " ",
           "preOp": " ",
         },
@@ -1619,7 +1578,6 @@ describe('SqlComparison', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": false,
         "op": "LIKE",
         "parens": undefined,
         "rhs": SqlLikePart {
@@ -1667,8 +1625,7 @@ describe('SqlComparison', () => {
       SqlComparison {
         "decorator": undefined,
         "keywords": Object {
-          "not": "NOT",
-          "op": "LIKE",
+          "op": "NOT LIKE",
         },
         "lhs": SqlColumn {
           "keywords": Object {},
@@ -1681,8 +1638,7 @@ describe('SqlComparison', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": true,
-        "op": "LIKE",
+        "op": "NOT LIKE",
         "parens": undefined,
         "rhs": SqlLikePart {
           "escape": SqlLiteral {
@@ -1712,7 +1668,6 @@ describe('SqlComparison', () => {
           "type": "likePart",
         },
         "spacing": Object {
-          "not": " ",
           "postOp": " ",
           "preOp": " ",
         },
@@ -1744,7 +1699,6 @@ describe('SqlComparison', () => {
             "table": undefined,
             "type": "column",
           },
-          "negated": false,
           "op": ">",
           "parens": undefined,
           "rhs": SqlColumn {
@@ -1786,7 +1740,6 @@ describe('SqlComparison', () => {
             "type": "literal",
             "value": "A",
           },
-          "negated": false,
           "op": ">",
           "parens": undefined,
           "rhs": SqlLiteral {
@@ -1828,7 +1781,6 @@ describe('SqlComparison', () => {
             "table": undefined,
             "type": "column",
           },
-          "negated": false,
           "op": ">",
           "parens": undefined,
           "rhs": SqlColumn {
@@ -1870,7 +1822,6 @@ describe('SqlComparison', () => {
             "type": "literal",
             "value": 1,
           },
-          "negated": false,
           "op": ">",
           "parens": undefined,
           "rhs": SqlLiteral {
@@ -1909,7 +1860,6 @@ describe('SqlComparison', () => {
             "type": "literal",
             "value": 1,
           },
-          "negated": undefined,
           "op": ">",
           "parens": Array [
             Object {
@@ -1956,7 +1906,6 @@ describe('SqlComparison', () => {
             "table": undefined,
             "type": "column",
           },
-          "negated": false,
           "op": "BETWEEN",
           "parens": undefined,
           "rhs": SqlBetweenPart {
@@ -2066,7 +2015,6 @@ describe('SqlComparison', () => {
                         "table": undefined,
                         "type": "column",
                       },
-                      "negated": false,
                       "op": "BETWEEN",
                       "parens": undefined,
                       "rhs": SqlBetweenPart {
@@ -2150,7 +2098,6 @@ describe('SqlComparison', () => {
             "table": undefined,
             "type": "column",
           },
-          "negated": false,
           "op": "BETWEEN",
           "parens": undefined,
           "rhs": SqlBetweenPart {

--- a/src/sql/sql-function/sql-function.spec.ts
+++ b/src/sql/sql-function/sql-function.spec.ts
@@ -641,7 +641,6 @@ describe('SqlFunction', () => {
               "table": undefined,
               "type": "column",
             },
-            "negated": false,
             "op": ">",
             "parens": undefined,
             "rhs": SqlLiteral {

--- a/src/sql/sql-multi/sql-multi.spec.ts
+++ b/src/sql/sql-multi/sql-multi.spec.ts
@@ -1148,7 +1148,6 @@ describe('Combined expression', () => {
                       "table": undefined,
                       "type": "column",
                     },
-                    "negated": false,
                     "op": ">",
                     "parens": undefined,
                     "rhs": SqlMulti {
@@ -1287,7 +1286,6 @@ describe('Combined expression', () => {
                       "spacing": Object {},
                       "type": "multi",
                     },
-                    "negated": false,
                     "op": ">",
                     "parens": undefined,
                     "rhs": SqlColumn {
@@ -1401,7 +1399,6 @@ describe('Combined expression', () => {
                       "table": undefined,
                       "type": "column",
                     },
-                    "negated": false,
                     "op": ">",
                     "parens": undefined,
                     "rhs": SqlMulti {
@@ -2260,7 +2257,6 @@ describe('getColumns', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": false,
         "op": "IS",
         "parens": undefined,
         "rhs": SqlLiteral {
@@ -2289,8 +2285,7 @@ describe('getColumns', () => {
       SqlComparison {
         "decorator": undefined,
         "keywords": Object {
-          "not": "NOT",
-          "op": "IS",
+          "op": "IS NOT",
         },
         "lhs": SqlColumn {
           "keywords": Object {},
@@ -2303,8 +2298,7 @@ describe('getColumns', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": true,
-        "op": "IS",
+        "op": "IS NOT",
         "parens": undefined,
         "rhs": SqlLiteral {
           "keywords": Object {},
@@ -2315,7 +2309,6 @@ describe('getColumns', () => {
           "value": null,
         },
         "spacing": Object {
-          "not": " ",
           "postOp": " ",
           "preOp": " ",
         },
@@ -2333,8 +2326,7 @@ describe('getColumns', () => {
       SqlComparison {
         "decorator": undefined,
         "keywords": Object {
-          "not": "NOT",
-          "op": "IS",
+          "op": "IS NOT",
         },
         "lhs": SqlColumn {
           "keywords": Object {},
@@ -2347,8 +2339,7 @@ describe('getColumns', () => {
           "table": undefined,
           "type": "column",
         },
-        "negated": true,
-        "op": "IS",
+        "op": "IS NOT",
         "parens": undefined,
         "rhs": SqlLiteral {
           "keywords": Object {},
@@ -2359,7 +2350,6 @@ describe('getColumns', () => {
           "value": true,
         },
         "spacing": Object {
-          "not": " ",
           "postOp": " ",
           "preOp": " ",
         },
@@ -2387,8 +2377,7 @@ describe('getColumns', () => {
             SqlComparison {
               "decorator": undefined,
               "keywords": Object {
-                "not": "NOT",
-                "op": "IS",
+                "op": "IS NOT",
               },
               "lhs": SqlColumn {
                 "keywords": Object {},
@@ -2401,8 +2390,7 @@ describe('getColumns', () => {
                 "table": undefined,
                 "type": "column",
               },
-              "negated": true,
-              "op": "IS",
+              "op": "IS NOT",
               "parens": undefined,
               "rhs": SqlLiteral {
                 "keywords": Object {},
@@ -2413,7 +2401,6 @@ describe('getColumns', () => {
                 "value": null,
               },
               "spacing": Object {
-                "not": " ",
                 "postOp": " ",
                 "preOp": " ",
               },
@@ -2435,7 +2422,6 @@ describe('getColumns', () => {
                 "table": undefined,
                 "type": "column",
               },
-              "negated": false,
               "op": "<>",
               "parens": undefined,
               "rhs": SqlLiteral {

--- a/src/sql/sql-query/sql-query.spec.ts
+++ b/src/sql/sql-query/sql-query.spec.ts
@@ -1516,7 +1516,6 @@ describe('SqlQuery', () => {
                 "table": undefined,
                 "type": "column",
               },
-              "negated": false,
               "op": ">",
               "parens": undefined,
               "rhs": SqlLiteral {
@@ -1644,7 +1643,6 @@ describe('SqlQuery', () => {
                 "table": undefined,
                 "type": "column",
               },
-              "negated": false,
               "op": "=",
               "parens": undefined,
               "rhs": SqlLiteral {
@@ -1792,7 +1790,6 @@ describe('SqlQuery', () => {
                             "table": undefined,
                             "type": "column",
                           },
-                          "negated": false,
                           "op": "=",
                           "parens": undefined,
                           "rhs": SqlLiteral {
@@ -1825,7 +1822,6 @@ describe('SqlQuery', () => {
                             "table": undefined,
                             "type": "column",
                           },
-                          "negated": false,
                           "op": ">",
                           "parens": undefined,
                           "rhs": SqlLiteral {
@@ -1866,7 +1862,6 @@ describe('SqlQuery', () => {
                       "table": undefined,
                       "type": "column",
                     },
-                    "negated": false,
                     "op": "=",
                     "parens": undefined,
                     "rhs": SqlLiteral {
@@ -2289,7 +2284,6 @@ describe('SqlQuery', () => {
                 "table": undefined,
                 "type": "column",
               },
-              "negated": false,
               "op": ">",
               "parens": undefined,
               "rhs": SqlLiteral {
@@ -2417,7 +2411,6 @@ describe('SqlQuery', () => {
                 "table": undefined,
                 "type": "column",
               },
-              "negated": false,
               "op": "=",
               "parens": undefined,
               "rhs": SqlLiteral {
@@ -2565,7 +2558,6 @@ describe('SqlQuery', () => {
                             "table": undefined,
                             "type": "column",
                           },
-                          "negated": false,
                           "op": "=",
                           "parens": undefined,
                           "rhs": SqlLiteral {
@@ -2598,7 +2590,6 @@ describe('SqlQuery', () => {
                             "table": undefined,
                             "type": "column",
                           },
-                          "negated": false,
                           "op": ">",
                           "parens": undefined,
                           "rhs": SqlLiteral {
@@ -2639,7 +2630,6 @@ describe('SqlQuery', () => {
                       "table": undefined,
                       "type": "column",
                     },
-                    "negated": false,
                     "op": "=",
                     "parens": undefined,
                     "rhs": SqlLiteral {
@@ -4370,7 +4360,6 @@ describe('SqlQuery', () => {
                       "table": undefined,
                       "type": "column",
                     },
-                    "negated": false,
                     "op": "=",
                     "parens": undefined,
                     "rhs": SqlColumn {
@@ -4511,7 +4500,6 @@ describe('SqlQuery', () => {
                       "table": undefined,
                       "type": "column",
                     },
-                    "negated": false,
                     "op": "=",
                     "parens": undefined,
                     "rhs": SqlColumn {
@@ -4652,7 +4640,6 @@ describe('SqlQuery', () => {
                       "table": undefined,
                       "type": "column",
                     },
-                    "negated": false,
                     "op": "=",
                     "parens": undefined,
                     "rhs": SqlColumn {
@@ -4793,7 +4780,6 @@ describe('SqlQuery', () => {
                       "table": undefined,
                       "type": "column",
                     },
-                    "negated": false,
                     "op": "=",
                     "parens": undefined,
                     "rhs": SqlColumn {
@@ -4934,7 +4920,6 @@ describe('SqlQuery', () => {
                       "table": undefined,
                       "type": "column",
                     },
-                    "negated": false,
                     "op": "=",
                     "parens": undefined,
                     "rhs": SqlColumn {
@@ -5746,7 +5731,6 @@ describe('SqlQuery', () => {
                       "table": undefined,
                       "type": "column",
                     },
-                    "negated": false,
                     "op": ">=",
                     "parens": undefined,
                     "rhs": SqlMulti {
@@ -5826,7 +5810,6 @@ describe('SqlQuery', () => {
                       "table": undefined,
                       "type": "column",
                     },
-                    "negated": false,
                     "op": "=",
                     "parens": undefined,
                     "rhs": SqlPlaceholder {

--- a/src/sql/sql-unary/sql-unary.spec.ts
+++ b/src/sql/sql-unary/sql-unary.spec.ts
@@ -241,7 +241,6 @@ describe('SqlUnary', () => {
             "table": undefined,
             "type": "column",
           },
-          "negated": false,
           "op": ">",
           "parens": undefined,
           "rhs": SqlColumn {
@@ -307,7 +306,6 @@ describe('SqlUnary', () => {
                   "table": undefined,
                   "type": "column",
                 },
-                "negated": false,
                 "op": ">",
                 "parens": undefined,
                 "rhs": SqlColumn {
@@ -354,7 +352,6 @@ describe('SqlUnary', () => {
                   "table": undefined,
                   "type": "column",
                 },
-                "negated": false,
                 "op": "=",
                 "parens": undefined,
                 "rhs": SqlLiteral {
@@ -416,7 +413,6 @@ describe('SqlUnary', () => {
               "table": undefined,
               "type": "column",
             },
-            "negated": false,
             "op": ">",
             "parens": undefined,
             "rhs": SqlColumn {


### PR DESCRIPTION
- make it so that `x NOT IN ('a', 'b')` is represented with `op = 'NOT IN'` (vs `IN` + `negate: true`)
- clean up the introspection functions so there is only one true way (that is much simpler to introspect) via `LIMIT 0`