### PR TITLE
Bump node

### DIFF
--- a/.changeset/beige-poets-accept.md
+++ b/.changeset/beige-poets-accept.md
@@ -1,0 +1,5 @@
+---
+'druid-query-toolkit': patch
+---
+
+Bump node to 20.19.5

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "node": ">= 14.17.0"
   },
   "volta": {
-    "node": "20.9.0"
+    "node": "20.19.5"
   },
   "dependencies": {
     "tslib": "^2.5.2"


### PR DESCRIPTION
Bump node to 20.19.5 so we can use the latest npm during publish